### PR TITLE
Update proteus for release v1.0

### DIFF
--- a/bin/dswx_hls.py
+++ b/bin/dswx_hls.py
@@ -86,7 +86,7 @@ def main():
         min_slope_angle = args.min_slope_angle,
         max_sun_local_inc_angle=args.max_sun_local_inc_angle,
         mask_adjacent_to_cloud_mode=args.mask_adjacent_to_cloud_mode,
-        copernicus_forest_classes=args.copernicus_forest_classes,
+        forest_mask_landcover_classes=args.forest_mask_landcover_classes,
         ocean_masking_shoreline_distance_km = \
             args.ocean_masking_shoreline_distance_km,
         flag_debug=args.flag_debug)

--- a/bin/dswx_hls.py
+++ b/bin/dswx_hls.py
@@ -82,6 +82,14 @@ def main():
         product_id=args.product_id,
         product_version=args.product_version,
         check_ancillary_inputs_coverage=args.check_ancillary_inputs_coverage,
+        aerosol_not_water_to_high_conf_water_fmask_values =
+            args.aerosol_not_water_to_high_conf_water_fmask_values,
+        aerosol_water_moderate_conf_to_high_conf_water_fmask_values =
+            args.aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
+        aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values =
+            args.aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
+        aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values =
+            args.aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values,
         shadow_masking_algorithm=args.shadow_masking_algorithm,
         min_slope_angle = args.min_slope_angle,
         max_sun_local_inc_angle=args.max_sun_local_inc_angle,

--- a/bin/dswx_hls.py
+++ b/bin/dswx_hls.py
@@ -82,6 +82,7 @@ def main():
         product_id=args.product_id,
         product_version=args.product_version,
         check_ancillary_inputs_coverage=args.check_ancillary_inputs_coverage,
+        apply_ocean_masking=args.apply_ocean_masking,
         apply_aerosol_class_remapping=args.apply_aerosol_class_remapping,
         aerosol_not_water_to_moderate_conf_water_fmask_values =
             args.aerosol_not_water_to_moderate_conf_water_fmask_values,

--- a/bin/dswx_hls.py
+++ b/bin/dswx_hls.py
@@ -84,14 +84,14 @@ def main():
         check_ancillary_inputs_coverage=args.check_ancillary_inputs_coverage,
         apply_ocean_masking=args.apply_ocean_masking,
         apply_aerosol_class_remapping=args.apply_aerosol_class_remapping,
-        aerosol_not_water_to_moderate_conf_water_fmask_values =
-            args.aerosol_not_water_to_moderate_conf_water_fmask_values,
+        aerosol_not_water_to_high_conf_water_fmask_values =
+            args.aerosol_not_water_to_high_conf_water_fmask_values,
         aerosol_water_moderate_conf_to_high_conf_water_fmask_values =
             args.aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
-        aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values =
-            args.aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values,
-        aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values =
-            args.aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values,
+        aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values =
+            args.aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
+        aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values =
+            args.aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values,
         shadow_masking_algorithm=args.shadow_masking_algorithm,
         min_slope_angle = args.min_slope_angle,
         max_sun_local_inc_angle=args.max_sun_local_inc_angle,

--- a/bin/dswx_hls.py
+++ b/bin/dswx_hls.py
@@ -82,15 +82,15 @@ def main():
         product_id=args.product_id,
         product_version=args.product_version,
         check_ancillary_inputs_coverage=args.check_ancillary_inputs_coverage,
-        apply_aerosol_masking=args.apply_aerosol_masking,
-        aerosol_not_water_to_high_conf_water_fmask_values =
-            args.aerosol_not_water_to_high_conf_water_fmask_values,
+        apply_aerosol_class_remapping=args.apply_aerosol_class_remapping,
+        aerosol_not_water_to_moderate_conf_water_fmask_values =
+            args.aerosol_not_water_to_moderate_conf_water_fmask_values,
         aerosol_water_moderate_conf_to_high_conf_water_fmask_values =
             args.aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
-        aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values =
-            args.aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
-        aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values =
-            args.aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values,
+        aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values =
+            args.aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values,
+        aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values =
+            args.aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values,
         shadow_masking_algorithm=args.shadow_masking_algorithm,
         min_slope_angle = args.min_slope_angle,
         max_sun_local_inc_angle=args.max_sun_local_inc_angle,

--- a/bin/dswx_hls.py
+++ b/bin/dswx_hls.py
@@ -82,6 +82,7 @@ def main():
         product_id=args.product_id,
         product_version=args.product_version,
         check_ancillary_inputs_coverage=args.check_ancillary_inputs_coverage,
+        apply_aerosol_masking=args.apply_aerosol_masking,
         aerosol_not_water_to_high_conf_water_fmask_values =
             args.aerosol_not_water_to_high_conf_water_fmask_values,
         aerosol_water_moderate_conf_to_high_conf_water_fmask_values =

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,12 +32,12 @@ RUN set -ex \
 
 # set default user and workdir
 WORKDIR /home/conda
-ADD dist/proteus-0.5.3.tar.gz .
+ADD dist/proteus-1.0.0.tar.gz .
 
 USER root
-RUN mkdir -p proteus-0.5.3/build
+RUN mkdir -p proteus-1.0.0/build
 RUN export PATH=/opt/conda/bin:$PATH
-WORKDIR /home/conda/proteus-0.5.3
+WORKDIR /home/conda/proteus-1.0.0
 RUN python3 setup.py install
 WORKDIR /home/conda
 
@@ -48,7 +48,7 @@ ENV GDAL_DIR /opt/conda
 ENV PATH $GDAL_DIR/bin:$PATH
 ENV GDAL_DATA $GDAL_DIR/share/gdal
 
-ENV PYTHONPATH /home/conda/proteus-0.5.3/src/:$PYTHONPATH
-ENV PATH /home/conda/proteus-0.5.3/bin/:$PATH
+ENV PYTHONPATH /home/conda/proteus-1.0.0/src/:$PYTHONPATH
+ENV PATH /home/conda/proteus-1.0.0/bin/:$PATH
 
 CMD [ "/bin/bash" ]

--- a/src/proteus/defaults/dswx_hls.yaml
+++ b/src/proteus/defaults/dswx_hls.yaml
@@ -72,21 +72,21 @@ runconfig:
             # Apply aeresol masking
             apply_aerosol_class_remapping: True
 
-            # HLS Fmask values to convert not-water to moderate-confidence water
+            # HLS Fmask values to convert not-water to high-confidence water
             # in the presence of high aerosol
-            aerosol_not_water_to_moderate_conf_water_fmask_values: [224, 160, 96]
+            aerosol_not_water_to_high_conf_water_fmask_values: [224, 160, 96]
 
             # HLS Fmask values to convert moderate-confidence water to
             # high-confidence water in the presence of high aerosol
             aerosol_water_moderate_conf_to_high_conf_water_fmask_values: [224, 160, 96]
 
             # HLS Fmask values to convert partial surface water conservative to
-            # moderate-confidence water in the presence of high aerosol
-            aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values: [224, 160]
+            # high-confidence water in the presence of high aerosol
+            aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values: [224, 160]
 
             # HLS Fmask values to convert partial surface water aggressive to
-            # moderateh-confidence water in the presence of high aerosol
-            aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values: [224, 160]
+            # high-confidence water in the presence of high aerosol
+            aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values: [224, 160]
 
             # Select shadow masking algorithm
             shadow_masking_algorithm: sun_local_inc_angle

--- a/src/proteus/defaults/dswx_hls.yaml
+++ b/src/proteus/defaults/dswx_hls.yaml
@@ -82,11 +82,11 @@ runconfig:
 
             # HLS Fmask values to convert partial surface water conservative to
             # high-confidence water in the presence of high aerosol
-            aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values: [224, 160]
+            aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values: [224, 192, 160, 96]
 
             # HLS Fmask values to convert partial surface water aggressive to
             # high-confidence water in the presence of high aerosol
-            aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values: [224, 160]
+            aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values: [224, 192, 160, 96]
 
             # Select shadow masking algorithm
             shadow_masking_algorithm: sun_local_inc_angle

--- a/src/proteus/defaults/dswx_hls.yaml
+++ b/src/proteus/defaults/dswx_hls.yaml
@@ -69,7 +69,7 @@ runconfig:
             # Apply ocean masking
             apply_ocean_masking: True
 
-            # Apply aeresol masking
+            # Apply aeresol class remapping
             apply_aerosol_class_remapping: True
 
             # HLS Fmask values to convert not-water to high-confidence water

--- a/src/proteus/defaults/dswx_hls.yaml
+++ b/src/proteus/defaults/dswx_hls.yaml
@@ -82,11 +82,11 @@ runconfig:
 
             # HLS Fmask values to convert partial surface water conservative to
             # high-confidence water in the presence of high aerosol
-            aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values: [224, 192, 160, 96]
+            aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values: [224, 192, 160, 128, 96]
 
             # HLS Fmask values to convert partial surface water aggressive to
             # high-confidence water in the presence of high aerosol
-            aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values: [224, 192, 160, 96]
+            aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values: [224, 192, 160, 128, 96]
 
             # Select shadow masking algorithm
             shadow_masking_algorithm: sun_local_inc_angle

--- a/src/proteus/defaults/dswx_hls.yaml
+++ b/src/proteus/defaults/dswx_hls.yaml
@@ -78,8 +78,10 @@ runconfig:
             # Define how areas adjacent to cloud/cloud-shadow should be handled
             mask_adjacent_to_cloud_mode: 'mask'
 
-            # Copernicus CGLS Land Cover 100m forest classes
-            copernicus_forest_classes: [20, 111, 113, 115, 116, 121, 123, 125, 126]
+            # Copernicus CGLS Land Cover 100m forest classes to mask out from
+            # the WTR-2 and WTR layer due to dark reflectance that is usually
+            # misinterpreted as water.
+            forest_mask_landcover_classes: [20, 111, 113, 115, 116, 121, 123, 125, 126]
 
             # Ocean masking distance from shoreline in km
             ocean_masking_shoreline_distance_km: 1

--- a/src/proteus/defaults/dswx_hls.yaml
+++ b/src/proteus/defaults/dswx_hls.yaml
@@ -66,6 +66,9 @@ runconfig:
             # Check if ancillary inputs cover entirely the output product
             check_ancillary_inputs_coverage: True
 
+            # Apply ocean masking
+            apply_ocean_masking: True
+
             # Apply aeresol masking
             apply_aerosol_class_remapping: True
 

--- a/src/proteus/defaults/dswx_hls.yaml
+++ b/src/proteus/defaults/dswx_hls.yaml
@@ -66,6 +66,9 @@ runconfig:
             # Check if ancillary inputs cover entirely the output product
             check_ancillary_inputs_coverage: True
 
+            # Apply aeresol masking
+            apply_aerosol_masking: True
+
             # HLS Fmask values to convert not-water to high-confidence water
             # in the presence of high aerosol
             aerosol_not_water_to_high_conf_water_fmask_values: [224, 160, 96]

--- a/src/proteus/defaults/dswx_hls.yaml
+++ b/src/proteus/defaults/dswx_hls.yaml
@@ -67,23 +67,23 @@ runconfig:
             check_ancillary_inputs_coverage: True
 
             # Apply aeresol masking
-            apply_aerosol_masking: True
+            apply_aerosol_class_remapping: True
 
-            # HLS Fmask values to convert not-water to high-confidence water
+            # HLS Fmask values to convert not-water to moderate-confidence water
             # in the presence of high aerosol
-            aerosol_not_water_to_high_conf_water_fmask_values: [224, 160, 96]
+            aerosol_not_water_to_moderate_conf_water_fmask_values: [224, 160, 96]
 
             # HLS Fmask values to convert moderate-confidence water to
             # high-confidence water in the presence of high aerosol
             aerosol_water_moderate_conf_to_high_conf_water_fmask_values: [224, 160, 96]
 
             # HLS Fmask values to convert partial surface water conservative to
-            # high-confidence water in the presence of high aerosol
-            aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values: [224, 160]
+            # moderate-confidence water in the presence of high aerosol
+            aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values: [224, 160]
 
             # HLS Fmask values to convert partial surface water aggressive to
-            # high-confidence water in the presence of high aerosol
-            aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values: [224, 160]
+            # moderateh-confidence water in the presence of high aerosol
+            aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values: [224, 160]
 
             # Select shadow masking algorithm
             shadow_masking_algorithm: sun_local_inc_angle

--- a/src/proteus/defaults/dswx_hls.yaml
+++ b/src/proteus/defaults/dswx_hls.yaml
@@ -66,6 +66,22 @@ runconfig:
             # Check if ancillary inputs cover entirely the output product
             check_ancillary_inputs_coverage: True
 
+            # HLS Fmask values to convert not-water to high-confidence water
+            # in the presence of high aerosol
+            aerosol_not_water_to_high_conf_water_fmask_values: [224, 160, 96]
+
+            # HLS Fmask values to convert moderate-confidence water to
+            # high-confidence water in the presence of high aerosol
+            aerosol_water_moderate_conf_to_high_conf_water_fmask_values: [224, 160, 96]
+
+            # HLS Fmask values to convert partial surface water conservative to
+            # high-confidence water in the presence of high aerosol
+            aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values: [224, 160]
+
+            # HLS Fmask values to convert partial surface water aggressive to
+            # high-confidence water in the presence of high aerosol
+            aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values: [224, 160]
+
             # Select shadow masking algorithm
             shadow_masking_algorithm: sun_local_inc_angle
 

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1149,7 +1149,7 @@ def _is_landcover_class_high_intensity_developed(landcover_mask):
     return high_intensity_developed_mask
 
 
-def _apply_aerosol_class_remapping_wtr1_class(wtr_1_layer, nir,
+def _apply_aerosol_class_remapping_single_class(wtr_1_layer, nir,
         preliminary_cloud_layer, fmask,
         fmask_values, input_wtr1_class, output_wtr1_class):
     """Apply aerosol remapping onto interpreted layer (WTR-1) given a
@@ -1176,14 +1176,9 @@ def _apply_aerosol_class_remapping_wtr1_class(wtr_1_layer, nir,
             Remapped WTR-1 class
     """
 
-    to_remap_array = None
-    for fmask_value in fmask_values:
-        if to_remap_array is None:
-            to_remap_array = fmask == fmask_value
-        else:
-            to_remap_array |= fmask == fmask_value
-    to_remap_array &= wtr_1_layer == input_wtr1_class
-    to_remap_array &= nir <= AEROSOL_REMAPPING_MAX_NIR
+    to_remap_array = ((np.isin(fmask, fmask_values)) &
+                      (wtr_1_layer == input_wtr1_class) &
+                      (nir <= AEROSOL_REMAPPING_MAX_NIR))
     wtr_1_layer[to_remap_array] = output_wtr1_class
 
     # set CLOUD layer bit (3): 2**3 = 8
@@ -1244,7 +1239,7 @@ def _apply_aerosol_class_remapping(wtr_1_layer, nir,
 
     for input_wtr1_class, (fmask_values, output_wtr1_class) in \
             wtr1_class_fmask_values_dict.items():
-        _apply_aerosol_class_remapping_wtr1_class(wtr_1_layer,
+        _apply_aerosol_class_remapping_single_class(wtr_1_layer,
             nir, preliminary_cloud_layer, fmask,
             fmask_values, input_wtr1_class, output_wtr1_class)
 

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -4315,7 +4315,7 @@ def generate_dswx_layers(input_list,
 
     # use floor integer to compute spatial and cloud coverage
     spatial_coverage = int(100 * float(n_valid) / total_number_of_pixels)
-    cloud_coverage = int(100 * float(n_cloud_and_valid) / total_number_of_pixels)
+    cloud_coverage = int(100 * float(n_cloud_and_valid) / n_valid)
 
     # print spatial and cloud coverage
     logger.info(f'    spatial coverage [%]:  {spatial_coverage}')

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1713,14 +1713,14 @@ def _compute_preliminary_cloud_layer(fmask, mask_adjacent_to_cloud_mode):
 
        Returns
        -------
-            preliminary_cloud_layer : numpy.ndarray
-                Preliminary cloud mask (without the snow/ice class)
-                with dtype of uint8 and values assigned as follows:
-                0: Not masked
-                1: Cloud shadow or adjacent to cloud/cloud shadow
-                4: Cloud
-                5: Cloud and class 1 (cloud shadow or adjacent to cloud/cloud shadow)
-                255: Fill value (no data)
+       preliminary_cloud_layer : numpy.ndarray
+           Preliminary cloud mask (without the snow/ice class)
+           with dtype of uint8 and values assigned as follows:
+           0: Not masked
+           1: Cloud shadow or adjacent to cloud/cloud shadow
+           4: Cloud
+           5: Cloud and class 1 (cloud shadow or adjacent to cloud/cloud shadow)
+           255: Fill value (no data)
 
        See Also
        ---------

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1496,7 +1496,9 @@ def _get_cloud_layer_ctable():
     mask_ctable.SetColorEntry(7, (127, 127, 255))
 
     # Light ocre - Aerosol reassignment ("0xE4CDA7")
-    mask_ctable.SetColorEntry(8, (228, 205, 167))
+    # mask_ctable.SetColorEntry(8, (228, 205, 167))
+    # Grayish blue - Aerosol reassignment ("0x7393B3")
+    mask_ctable.SetColorEntry(8, (115, 147, 179))
     # Dark gray - Cloud shadow
     mask_ctable.SetColorEntry(9, (64, 64, 64))
     # Cyan - snow/ice

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1154,9 +1154,13 @@ def _apply_aerosol_masking_wtr1_class(wtr_1_layer, fmask, wtr1_class,
             in the presence of high aerosol
     """
 
-    to_mask_array = wtr_1_layer == wtr1_class
+    to_mask_array = None
     for fmask_value in fmask_values:
-        to_mask_array &= fmask == fmask_value
+        if to_mask_array is None:
+            to_mask_array = fmask == fmask_value
+        else:
+            to_mask_array |= fmask == fmask_value
+    to_mask_array &= wtr_1_layer == wtr1_class
     wtr_1_layer[to_mask_array] = WATER_UNCOLLAPSED_HIGH_CONF_CLEAR
 
 

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1195,7 +1195,7 @@ def _apply_aerosol_masking(wtr_1_layer, fmask,
     wtr1_class_fmask_values_dict = {
         WATER_NOT_WATER_CLEAR:
             (aerosol_not_water_to_high_conf_water_fmask_values,
-             WATER_UNCOLLAPSED_HIGH_CONF_CLEAR),
+             WATER_UNCOLLAPSED_MODERATE_CONF_CLEAR),
         WATER_UNCOLLAPSED_MODERATE_CONF_CLEAR:
             (aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
              WATER_UNCOLLAPSED_HIGH_CONF_CLEAR),

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -3719,7 +3719,8 @@ def _compute_hillshade(dem_file, scratch_dir, sun_azimuth_angle,
 def _compute_opera_shadow_layer(dem, sun_azimuth_angle, sun_elevation_angle,
                                 min_slope_angle, max_sun_local_inc_angle,
                                 pixel_spacing_x = 30, pixel_spacing_y = 30):
-    """Compute hillshade using new OPERA shadow masking
+    """Compute shadow mask based on Sun local incidence angle and slope
+       angle.
 
        Parameters
        ----------
@@ -3742,8 +3743,8 @@ def _compute_opera_shadow_layer(dem, sun_azimuth_angle, sun_elevation_angle,
 
        Returns
        -------
-       hillshade : numpy.ndarray
-              Hillshade
+       shadow_mask : numpy.ndarray
+              Shadow mask (1: not shadow, 0: shadow)
     """
     sun_azimuth = np.radians(sun_azimuth_angle)
     sun_zenith_degrees = 90 - sun_elevation_angle

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -315,20 +315,20 @@ class RunConfigConstants:
         HLS reflectance thresholds for generating DSWx-HLS products
     check_ancillary_inputs_coverage: bool
         Check if ancillary inputs cover entirely the output product
-    apply_aerosol_masking: bool
+    apply_aerosol_class_remapping: bool
         Apply aerosol masking
-    aerosol_not_water_to_high_conf_water_fmask_values: list(int)
-         HLS Fmask values to convert not-water to high-confidence water
+    aerosol_not_water_to_moderate_conf_water_fmask_values: list(int)
+         HLS Fmask values to convert not-water to moderate-confidence water
          in the presence of high aerosol
     aerosol_water_moderate_conf_to_high_conf_water_fmask_values: list(int)
          HLS Fmask values to convert moderate-confidence water to
          high-confidence water in the presence of high aerosol
-    aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values: list(int)
+    aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values: list(int)
          HLS Fmask values to convert partial surface water conservative to
-         high-confidence water in the presence of high aerosol
-    aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values: list(int)
+         moderate-confidence water in the presence of high aerosol
+    aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values: list(int)
          HLS Fmask values to convert partial surface water aggressive to
-         high-confidence water in the presence of high aerosol
+         moderate-confidence water in the presence of high aerosol
     shadow_masking_algorithm: str
         Shadow masking algorithm
     min_slope_angle: float
@@ -373,11 +373,11 @@ class RunConfigConstants:
     def __init__(self):
         self.hls_thresholds = HlsThresholds()
         self.check_ancillary_inputs_coverage = None
-        self.apply_aerosol_masking = None
-        self.aerosol_not_water_to_high_conf_water_fmask_values = None
+        self.apply_aerosol_class_remapping = None
+        self.aerosol_not_water_to_moderate_conf_water_fmask_values = None
         self.aerosol_water_moderate_conf_to_high_conf_water_fmask_values = None
-        self.aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values = None
-        self.aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values = None
+        self.aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values = None
+        self.aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values = None
         self.shadow_masking_algorithm = None
         self.min_slope_angle = None
         self.max_sun_local_inc_angle = None
@@ -618,7 +618,7 @@ def get_dswx_hls_cli_parser():
                               ' the output product'))
 
     parser.add_argument('--apply-aerosol-masking',
-                        dest='apply_aerosol_masking',
+                        dest='apply_aerosol_class_remapping',
                         action='store_true',
                         default=None,
                         help='Apply aerosol masking')
@@ -1135,7 +1135,7 @@ def _is_landcover_class_high_intensity_developed(landcover_mask):
     return high_intensity_developed_mask
 
 
-def _apply_aerosol_masking_wtr1_class(wtr_1_layer, fmask,
+def _apply_aerosol_class_remapping_wtr1_class(wtr_1_layer, fmask,
         fmask_values, input_wtr1_class, output_wtr1_class):
     """Apply aerosol masking onto interpreted layer (WTR-1) given a
        WTR-1 class and fmask values
@@ -1147,12 +1147,12 @@ def _apply_aerosol_masking_wtr1_class(wtr_1_layer, fmask,
        fmask: numpy.ndarray
             HLS Fmask
        fmask_values: list(int)
-            HLS Fmask values to convert not-water to high-confidence water
+            HLS Fmask values to remap interpreted water classes
             in the presence of high aerosol
        input_wtr1_class: int
             Input WTR-1 class that is being evaluated for high-aerosol
        output_wtr1_class: int
-            Output WTR-1 class if input WTR-1 class has high-aerosol
+            Remapped WTR-1 class
     """
 
     to_mask_array = None
@@ -1165,11 +1165,11 @@ def _apply_aerosol_masking_wtr1_class(wtr_1_layer, fmask,
     wtr_1_layer[to_mask_array] = output_wtr1_class
 
 
-def _apply_aerosol_masking(wtr_1_layer, fmask,
-        aerosol_not_water_to_high_conf_water_fmask_values,
+def _apply_aerosol_class_remapping(wtr_1_layer, fmask,
+        aerosol_not_water_to_moderate_conf_water_fmask_values,
         aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
-        aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
-        aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values):
+        aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values,
+        aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values):
     """Apply aerosol masking onto interpreted layer (WTR-1)
 
        Parameters
@@ -1178,38 +1178,39 @@ def _apply_aerosol_masking(wtr_1_layer, fmask,
             Interpreted layer (WTR-1) (mutable numpy.ndarray)
        fmask: numpy.ndarray
             HLS Fmask
-       aerosol_not_water_to_high_conf_water_fmask_values: list(int)
-           HLS Fmask values to convert not-water to high-confidence water
+       aerosol_not_water_to_moderate_conf_water_fmask_values: list(int)
+           HLS Fmask values to convert not-water to moderate-confidence water
            in the presence of high aerosol
        aerosol_water_moderate_conf_to_high_conf_water_fmask_values: list(int)
            HLS Fmask values to convert moderate-confidence water to
            high-confidence water in the presence of high aerosol
-       aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values: list(int)
+       aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values: list(int)
            HLS Fmask values to convert partial surface water conservative to
-           high-confidence water in the presence of high aerosol
-       aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values: list(int)
+           moderate-confidence water in the presence of high aerosol
+       aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values: list(int)
            HLS Fmask values to convert partial surface water aggressive to
-           high-confidence water in the presence of high aerosol
+           moderate-confidence water in the presence of high aerosol
     """
 
+    # add a not here that nothing changes for high-conf. water
     wtr1_class_fmask_values_dict = {
         WATER_NOT_WATER_CLEAR:
-            (aerosol_not_water_to_high_conf_water_fmask_values,
+            (aerosol_not_water_to_moderate_conf_water_fmask_values,
              WATER_UNCOLLAPSED_MODERATE_CONF_CLEAR),
         WATER_UNCOLLAPSED_MODERATE_CONF_CLEAR:
             (aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
              WATER_UNCOLLAPSED_HIGH_CONF_CLEAR),
         WATER_UNCOLLAPSED_PARTIAL_SURFACE_WATER_CONSERVATIVE_CLEAR:
-            (aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
+            (aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values,
              WATER_UNCOLLAPSED_MODERATE_CONF_CLEAR),
         WATER_UNCOLLAPSED_PARTIAL_SURFACE_WATER_AGGRESSIVE_CLEAR:
-            (aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values,
+            (aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values,
              WATER_UNCOLLAPSED_MODERATE_CONF_CLEAR)
         }
 
     for input_wtr1_class, (fmask_values, output_wtr1_class) in \
             wtr1_class_fmask_values_dict.items():
-        _apply_aerosol_masking_wtr1_class(wtr_1_layer, fmask,
+        _apply_aerosol_class_remapping_wtr1_class(wtr_1_layer, fmask,
             fmask_values, input_wtr1_class, output_wtr1_class)
 
 
@@ -1459,6 +1460,8 @@ def _get_cloud_layer_ctable():
     # - Mask cloud shadow bit (0)
     # - Mask snow/ice bit (1)
     # - Mask cloud bit (2)
+    # - Class re-assignment due to aerosol interpolation errors (3)
+    # rusty ocre / gray green / grayish yellow
 
     # White - Not masked
     mask_ctable.SetColorEntry(0, (255, 255, 255))
@@ -1478,6 +1481,7 @@ def _get_cloud_layer_ctable():
     mask_ctable.SetColorEntry(7, (127, 127, 255))
     # Dark blue - Ocean masked
     mask_ctable.SetColorEntry(CLOUD_OCEAN_MASKED, OCEAN_MASKED_RGBA)
+
     # Black - Fill value
     mask_ctable.SetColorEntry(UINT8_FILL_VALUE, FILL_VALUE_RGBA)
     return mask_ctable
@@ -3658,10 +3662,10 @@ def _populate_dswx_metadata_datasets(dswx_metadata_dict,
 
 def _populate_dswx_metadata_processing_parameters(
         dswx_metadata_dict,
-        aerosol_not_water_to_high_conf_water_fmask_values,
+        aerosol_not_water_to_moderate_conf_water_fmask_values,
         aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
-        aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
-        aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values,
+        aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values,
+        aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values,
         shadow_masking_algorithm,
         min_slope_angle,
         max_sun_local_inc_angle,
@@ -3675,18 +3679,18 @@ def _populate_dswx_metadata_processing_parameters(
        ----------
        dswx_metadata_dict : collections.OrderedDict
               Metadata dictionary
-       aerosol_not_water_to_high_conf_water_fmask_values: list(int)
-              HLS Fmask values to convert not-water to high-confidence water
+       aerosol_not_water_to_moderate_conf_water_fmask_values: list(int)
+              HLS Fmask values to convert not-water to moderate-confidence water
               in the presence of high aerosol
        aerosol_water_moderate_conf_to_high_conf_water_fmask_values: list(int)
               HLS Fmask values to convert moderate-confidence water to
               high-confidence water in the presence of high aerosol
-       aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values: list(int)
+       aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values: list(int)
               HLS Fmask values to convert partial surface water conservative to
-              high-confidence water in the presence of high aerosol
-       aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values: list(int)
+              moderate-confidence water in the presence of high aerosol
+       aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values: list(int)
               HLS Fmask values to convert partial surface water aggressive to
-              high-confidence water in the presence of high aerosol
+              moderate-confidence water in the presence of high aerosol
        shadow_masking_algorithm: str
               Shadow masking algorithm
        min_slope_angle: float
@@ -3707,14 +3711,14 @@ def _populate_dswx_metadata_processing_parameters(
 
     # aerosol metadata fields
     aerosol_metadata_dict = {
-        'aerosol_not_water_to_high_conf_water_fmask_values':
-            aerosol_not_water_to_high_conf_water_fmask_values,
+        'aerosol_not_water_to_moderate_conf_water_fmask_values':
+            aerosol_not_water_to_moderate_conf_water_fmask_values,
         'aerosol_water_moderate_conf_to_high_conf_water_fmask_values':
             aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
-        'aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values':
-            aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
-        'aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values':
-            aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values,
+        'aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values':
+            aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values,
+        'aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values':
+            aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values,
     }
 
     for aerosol_metadata_field_lower, fmask_values in aerosol_metadata_dict.items():
@@ -4154,11 +4158,11 @@ def generate_dswx_layers(input_list,
                          product_id=None,
                          product_version=SOFTWARE_VERSION,
                          check_ancillary_inputs_coverage=None,
-                         apply_aerosol_masking=None,
-                         aerosol_not_water_to_high_conf_water_fmask_values=None,
+                         apply_aerosol_class_remapping=None,
+                         aerosol_not_water_to_moderate_conf_water_fmask_values=None,
                          aerosol_water_moderate_conf_to_high_conf_water_fmask_values=None,
-                         aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values=None,
-                         aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values=None,
+                         aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values=None,
+                         aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values=None,
                          shadow_masking_algorithm=None,
                          min_slope_angle=None,
                          max_sun_local_inc_angle=None,
@@ -4246,20 +4250,20 @@ def generate_dswx_layers(input_list,
               metadata
        check_ancillary_inputs_coverage: bool (optional)
               Check if ancillary inputs cover entirely the output product
-       apply_aerosol_masking: bool (optional)
+       apply_aerosol_class_remapping: bool (optional)
               Apply aerosol masking
-       aerosol_not_water_to_high_conf_water_fmask_values: list(int) (optional)
-              HLS Fmask values to convert not-water to high-confidence water
+       aerosol_not_water_to_moderate_conf_water_fmask_values: list(int) (optional)
+              HLS Fmask values to convert not-water to moderate-confidence water
               in the presence of high aerosol
        aerosol_water_moderate_conf_to_high_conf_water_fmask_values: list(int) (optional)
               HLS Fmask values to convert moderate-confidence water to
               high-confidence water in the presence of high aerosol
-       aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values: list(int) (optional)
+       aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values: list(int) (optional)
               HLS Fmask values to convert partial surface water conservative to
-              high-confidence water in the presence of high aerosol
-       aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values: list(int) (optional)
+              moderate-confidence water in the presence of high aerosol
+       aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values: list(int) (optional)
               HLS Fmask values to convert partial surface water aggressive to
-              high-confidence water in the presence of high aerosol
+              moderate-confidence water in the presence of high aerosol
        shadow_masking_algorithm: str (optional)
               Shadow masking algorithm. Choices: "otsu" or "sun_local_inc_angle"
        min_slope_angle: float (optional)
@@ -4285,11 +4289,11 @@ def generate_dswx_layers(input_list,
     flag_read_runconfig_constants = \
         any([p is None for p in [hls_thresholds,
                                  check_ancillary_inputs_coverage,
-                                 apply_aerosol_masking,
-                                 aerosol_not_water_to_high_conf_water_fmask_values,
+                                 apply_aerosol_class_remapping,
+                                 aerosol_not_water_to_moderate_conf_water_fmask_values,
                                  aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
-                                 aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
-                                 aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values,
+                                 aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values,
+                                 aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values,
                                  shadow_masking_algorithm,
                                  min_slope_angle,
                                  max_sun_local_inc_angle,
@@ -4310,20 +4314,20 @@ def generate_dswx_layers(input_list,
         if check_ancillary_inputs_coverage is None:
             check_ancillary_inputs_coverage = \
                 runconfig_constants.check_ancillary_inputs_coverage
-        if apply_aerosol_masking is None:
-            apply_aerosol_masking = runconfig.constants.apply_aerosol_masking
-        if aerosol_not_water_to_high_conf_water_fmask_values is None:
-            aerosol_not_water_to_high_conf_water_fmask_values = \
-                runconfig_constants.aerosol_not_water_to_high_conf_water_fmask_values
+        if apply_aerosol_class_remapping is None:
+            apply_aerosol_class_remapping = runconfig.constants.apply_aerosol_class_remapping
+        if aerosol_not_water_to_moderate_conf_water_fmask_values is None:
+            aerosol_not_water_to_moderate_conf_water_fmask_values = \
+                runconfig_constants.aerosol_not_water_to_moderate_conf_water_fmask_values
         if aerosol_water_moderate_conf_to_high_conf_water_fmask_values is None:
             aerosol_water_moderate_conf_to_high_conf_water_fmask_values = \
                 runconfig_constants.aerosol_water_moderate_conf_to_high_conf_water_fmask_values
-        if aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values is None:
-            aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values = \
-                runconfig_constants.aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values
-        if aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values is None:
-            aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values = \
-                runconfig_constants.aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values
+        if aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values is None:
+            aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values = \
+                runconfig_constants.aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values
+        if aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values is None:
+            aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values = \
+                runconfig_constants.aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values
         if shadow_masking_algorithm is None:
             shadow_masking_algorithm = \
                 runconfig_constants.shadow_masking_algorithm
@@ -4390,30 +4394,30 @@ def generate_dswx_layers(input_list,
                 f' {check_ancillary_inputs_coverage}')
                 
     logger.info(f'    apply aerosol masking:'
-                f' {apply_aerosol_masking}')
-    if apply_aerosol_masking:
-        aerosol_masking_unused_parameters_str = ''
+                f' {apply_aerosol_class_remapping}')
+    if apply_aerosol_class_remapping:
+        aerosol_class_remapping_unused_parameters_str = ''
     else:
-        aerosol_masking_unused_parameters_str = ' (unused)'
+        aerosol_class_remapping_unused_parameters_str = ' (unused)'
     logger.info(
-        f'        not-water to high-confidence water Fmask values:' +
-        f' {aerosol_not_water_to_high_conf_water_fmask_values}' +
-        aerosol_masking_unused_parameters_str)
+        f'        not-water to moderate-confidence water Fmask values:' +
+        f' {aerosol_not_water_to_moderate_conf_water_fmask_values}' +
+        aerosol_class_remapping_unused_parameters_str)
     logger.info(
         f'        moderate confidence water to'
         f' high-confidence water Fmask values:' +
         f' {aerosol_water_moderate_conf_to_high_conf_water_fmask_values}' +
-        aerosol_masking_unused_parameters_str)
+        aerosol_class_remapping_unused_parameters_str)
     logger.info(
         f'        partial surface water conservative to'
-        f' high-confidence water Fmask values:' +
-        f' {aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values}' +
-        aerosol_masking_unused_parameters_str)
+        f' moderate-confidence water Fmask values:' +
+        f' {aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values}' +
+        aerosol_class_remapping_unused_parameters_str)
     logger.info(
         f'        partial surface water aggressive to'
-        f' high-confidence water Fmask values:' +
-        f' {aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values}' +
-        aerosol_masking_unused_parameters_str)
+        f' moderate-confidence water Fmask values:' +
+        f' {aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values}' +
+        aerosol_class_remapping_unused_parameters_str)
     logger.info(f'    shadow masking algorithm: {shadow_masking_algorithm}')
     if shadow_masking_algorithm == 'otsu':
         terrain_masking_parameters_str = ' (unused)'
@@ -4497,14 +4501,14 @@ def generate_dswx_layers(input_list,
 
     _populate_dswx_metadata_processing_parameters(
         dswx_metadata_dict,
-        aerosol_not_water_to_high_conf_water_fmask_values =
-            aerosol_not_water_to_high_conf_water_fmask_values,
+        aerosol_not_water_to_moderate_conf_water_fmask_values =
+            aerosol_not_water_to_moderate_conf_water_fmask_values,
         aerosol_water_moderate_conf_to_high_conf_water_fmask_values =
             aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
-        aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values =
-            aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
-        aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values =
-            aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values,
+        aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values =
+            aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values,
+        aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values =
+            aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values,
         shadow_masking_algorithm=shadow_masking_algorithm,
         min_slope_angle=min_slope_angle,
         max_sun_local_inc_angle=max_sun_local_inc_angle,
@@ -4618,7 +4622,7 @@ def generate_dswx_layers(input_list,
 
     # update DSWx-HLS metadata dictionary
     dswx_metadata_dict['SPATIAL_COVERAGE'] = spatial_coverage
-    dswx_metadata_dict['SPATIAL_COVERAGE_AFTER_OCEAN_MASKING'] = \
+    dswx_metadata_dict['SPATIAL_COVERAGE_EXCLUDING_MASKED_OCEAN'] = \
         spatial_coverage_after_ocean_masking
     dswx_metadata_dict['CLOUD_COVERAGE'] = cloud_coverage
 
@@ -4744,12 +4748,12 @@ def generate_dswx_layers(input_list,
                           scratch_dir=scratch_dir,
                           output_files_list=build_vrt_list)
 
-    if apply_aerosol_masking:
-        _apply_aerosol_masking(wtr_1_layer, fmask,
-            aerosol_not_water_to_high_conf_water_fmask_values,
+    if apply_aerosol_class_remapping:
+        _apply_aerosol_class_remapping(wtr_1_layer, fmask,
+            aerosol_not_water_to_moderate_conf_water_fmask_values,
             aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
-            aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
-            aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values)
+            aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values,
+            aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values)
 
     wtr_2_layer = _apply_landcover_and_shadow_masks(
         wtr_1_layer, nir, landcover_mask, shadow_layer,

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -4544,7 +4544,6 @@ def generate_dswx_layers(input_list,
     cloud = _add_snow_to_cloud_layer(
         wtr_2_layer, preliminary_cloud_layer, fmask,
         mask_adjacent_to_cloud_mode)
-    del preliminary_cloud_layer
 
     wtr_layer = _apply_cloud_masking(wtr_2_layer, cloud)
 

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -3500,6 +3500,7 @@ def _populate_dswx_metadata_processing_parameters(
         max_sun_local_inc_angle,
         mask_adjacent_to_cloud_mode,
         forest_mask_landcover_classes,
+        shoreline_shapefile,
         ocean_masking_shoreline_distance_km):
     """Populate metadata dictionary with processing parameters
 
@@ -3519,6 +3520,8 @@ def _populate_dswx_metadata_processing_parameters(
               Copernicus CGLS Land Cover 100m forest classes to mask out from
               the WTR-2 and WTR layer due to dark reflectance that is usually
               misinterpreted as water.
+       shoreline_shapefile:
+              NOAA shoreline shapefile
        ocean_masking_shoreline_distance_km: float
               Ocean masking distance from shoreline in km
     """
@@ -3541,8 +3544,11 @@ def _populate_dswx_metadata_processing_parameters(
         ','.join([str(c) for c in forest_mask_landcover_classes])
 
     # ocean masking distance from shoreline in km
-    dswx_metadata_dict['OCEAN_MASKING_SHORELINE_DISTANCE_KM'] = \
-        ocean_masking_shoreline_distance_km
+    if shoreline_shapefile:
+        dswx_metadata_dict['OCEAN_MASKING_SHORELINE_DISTANCE_KM'] = \
+            ocean_masking_shoreline_distance_km
+    else:
+        dswx_metadata_dict['OCEAN_MASKING_SHORELINE_DISTANCE_KM'] = '-'
 
 
 class Logger(object):
@@ -4231,6 +4237,7 @@ def generate_dswx_layers(input_list,
         max_sun_local_inc_angle=max_sun_local_inc_angle,
         mask_adjacent_to_cloud_mode=mask_adjacent_to_cloud_mode,
         forest_mask_landcover_classes=forest_mask_landcover_classes,
+        shoreline_shapefile = shoreline_shapefile,
         ocean_masking_shoreline_distance_km =
             ocean_masking_shoreline_distance_km)
 

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1346,7 +1346,7 @@ def _get_interpreted_dswx_ctable(
                                   (0, 0, 255)) 
         # Light blue - Water (moderate conf.)
         dswx_ctable.SetColorEntry(WATER_UNCOLLAPSED_MODERATE_CONF_CLEAR,
-                                  (173, 173, 252))
+                                  (0, 127, 255))
         # Dark green - Partial surface water conservative
         dswx_ctable.SetColorEntry(
             WATER_UNCOLLAPSED_PARTIAL_SURFACE_WATER_CONSERVATIVE_CLEAR, 

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -32,7 +32,10 @@ FLAG_CLIP_NEGATIVE_REFLECTANCE = True
 
 landcover_mask_type = 'standard'
 
-AEROSOL_REMAPPING_MAX_NIR = 0.1
+
+# HLS thresholds are evaluated over unscalled reflactance values
+SCALE_FACTOR = 0.0001
+AEROSOL_REMAPPING_MAX_NIR = 0.1 / SCALE_FACTOR
 
 COMPARE_DSWX_HLS_PRODUCTS_ERROR_TOLERANCE = 1e-6
 

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1486,6 +1486,7 @@ def _get_cloud_layer_ctable():
     mask_ctable = gdal.ColorTable()
 
     # set color for each value
+    # Bit encoding:
     # - Mask cloud shadow bit (0)
     # - Mask snow/ice bit (1)
     # - Mask cloud bit (2)
@@ -1691,7 +1692,13 @@ def _get_confidence_layer(wtr_2_layer, cloud_layer):
 
     Notes
     -----
-    CLOUD layer classifications (as of Nov. 2022)
+    CLOUD layer classifications
+    Bit encoding:
+    - Mask cloud shadow bit (0)
+    - Mask snow/ice bit (1)
+    - Mask cloud bit (2)
+    - Class reassignment due to aerosol interpolation errors (3)
+    CLOUD classes
     0: Not masked
     1: Cloud shadow
     2: Snow/ice
@@ -1700,14 +1707,14 @@ def _get_confidence_layer(wtr_2_layer, cloud_layer):
     5: Cloud and cloud shadow
     6: Cloud and snow/ice
     7: Cloud, cloud shadow, and snow/ice
-    8: Aerosol remapped
-    9: Aerosol remapped and cloud shadow
-    10: Aerosol remapped and snow/ice
-    11: Aerosol remapped, cloud shadow and snow/ice
-    12: Aerosol remapped and cloud
-    13: Aerosol remapped, cloud, and cloud shadow
-    14: Aerosol remapped, cloud ,and snow/ice
-    15: Aerosol remapped, cloud, cloud shadow, and snow/ice
+    8: Aerosol reassigned class
+    9: Aerosol reassigned class and cloud shadow
+    10: Aerosol reassigned class and snow/ice
+    11: Aerosol reassigned class, cloud shadow and snow/ice
+    12: Aerosol reassigned class and cloud
+    13: Aerosol reassigned class, cloud, and cloud shadow
+    14: Aerosol reassigned class, cloud ,and snow/ice
+    15: Aerosol reassigned class, cloud, cloud shadow, and snow/ice
     255: Fill value (no data)
     The cloud classification in the CONF layer represents
     the ensemble of cloud, cloud shadow, or adjacent-to-cloud

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -319,18 +319,18 @@ class RunConfigConstants:
         Apply ocean masking
     apply_aerosol_class_remapping: bool
         Apply aerosol masking
-    aerosol_not_water_to_moderate_conf_water_fmask_values: list(int)
-         HLS Fmask values to convert not-water to moderate-confidence water
+    aerosol_not_water_to_high_conf_water_fmask_values: list(int)
+         HLS Fmask values to convert not-water to high-confidence water
          in the presence of high aerosol
     aerosol_water_moderate_conf_to_high_conf_water_fmask_values: list(int)
          HLS Fmask values to convert moderate-confidence water to
          high-confidence water in the presence of high aerosol
-    aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values: list(int)
+    aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values: list(int)
          HLS Fmask values to convert partial surface water conservative to
-         moderate-confidence water in the presence of high aerosol
-    aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values: list(int)
+         high-confidence water in the presence of high aerosol
+    aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values: list(int)
          HLS Fmask values to convert partial surface water aggressive to
-         moderate-confidence water in the presence of high aerosol
+         high-confidence water in the presence of high aerosol
     shadow_masking_algorithm: str
         Shadow masking algorithm
     min_slope_angle: float
@@ -377,10 +377,10 @@ class RunConfigConstants:
         self.check_ancillary_inputs_coverage = None
         self.apply_ocean_masking = None
         self.apply_aerosol_class_remapping = None
-        self.aerosol_not_water_to_moderate_conf_water_fmask_values = None
+        self.aerosol_not_water_to_high_conf_water_fmask_values = None
         self.aerosol_water_moderate_conf_to_high_conf_water_fmask_values = None
-        self.aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values = None
-        self.aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values = None
+        self.aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values = None
+        self.aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values = None
         self.shadow_masking_algorithm = None
         self.min_slope_angle = None
         self.max_sun_local_inc_angle = None
@@ -1187,10 +1187,10 @@ def _apply_aerosol_class_remapping_wtr1_class(wtr_1_layer,
 
 def _apply_aerosol_class_remapping(wtr_1_layer,
         preliminary_cloud_layer, fmask,
-        aerosol_not_water_to_moderate_conf_water_fmask_values,
+        aerosol_not_water_to_high_conf_water_fmask_values,
         aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
-        aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values,
-        aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values):
+        aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
+        aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values):
     """Apply aerosol masking onto interpreted layer (WTR-1)
 
        Parameters
@@ -1202,33 +1202,33 @@ def _apply_aerosol_class_remapping(wtr_1_layer,
             numpy.ndarray)
        fmask: numpy.ndarray
             HLS Fmask
-       aerosol_not_water_to_moderate_conf_water_fmask_values: list(int)
-           HLS Fmask values to convert not-water to moderate-confidence water
+       aerosol_not_water_to_high_conf_water_fmask_values: list(int)
+           HLS Fmask values to convert not-water to high-confidence water
            in the presence of high aerosol
        aerosol_water_moderate_conf_to_high_conf_water_fmask_values: list(int)
            HLS Fmask values to convert moderate-confidence water to
            high-confidence water in the presence of high aerosol
-       aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values: list(int)
+       aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values: list(int)
            HLS Fmask values to convert partial surface water conservative to
-           moderate-confidence water in the presence of high aerosol
-       aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values: list(int)
+           high-confidence water in the presence of high aerosol
+       aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values: list(int)
            HLS Fmask values to convert partial surface water aggressive to
-           moderate-confidence water in the presence of high aerosol
+           high-confidence water in the presence of high aerosol
     """
 
     # add a not here that nothing changes for high-confidence water
     wtr1_class_fmask_values_dict = {
         WATER_NOT_WATER_CLEAR:
-            (aerosol_not_water_to_moderate_conf_water_fmask_values,
+            (aerosol_not_water_to_high_conf_water_fmask_values,
              WATER_UNCOLLAPSED_MODERATE_CONF_CLEAR),
         WATER_UNCOLLAPSED_MODERATE_CONF_CLEAR:
             (aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
              WATER_UNCOLLAPSED_HIGH_CONF_CLEAR),
         WATER_UNCOLLAPSED_PARTIAL_SURFACE_WATER_CONSERVATIVE_CLEAR:
-            (aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values,
+            (aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
              WATER_UNCOLLAPSED_MODERATE_CONF_CLEAR),
         WATER_UNCOLLAPSED_PARTIAL_SURFACE_WATER_AGGRESSIVE_CLEAR:
-            (aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values,
+            (aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values,
              WATER_UNCOLLAPSED_MODERATE_CONF_CLEAR)
         }
 
@@ -3707,10 +3707,10 @@ def _populate_dswx_metadata_datasets(dswx_metadata_dict,
 
 def _populate_dswx_metadata_processing_parameters(
         dswx_metadata_dict,
-        aerosol_not_water_to_moderate_conf_water_fmask_values,
+        aerosol_not_water_to_high_conf_water_fmask_values,
         aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
-        aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values,
-        aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values,
+        aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
+        aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values,
         shadow_masking_algorithm,
         min_slope_angle,
         max_sun_local_inc_angle,
@@ -3724,18 +3724,18 @@ def _populate_dswx_metadata_processing_parameters(
        ----------
        dswx_metadata_dict : collections.OrderedDict
               Metadata dictionary
-       aerosol_not_water_to_moderate_conf_water_fmask_values: list(int)
-              HLS Fmask values to convert not-water to moderate-confidence water
+       aerosol_not_water_to_high_conf_water_fmask_values: list(int)
+              HLS Fmask values to convert not-water to high-confidence water
               in the presence of high aerosol
        aerosol_water_moderate_conf_to_high_conf_water_fmask_values: list(int)
               HLS Fmask values to convert moderate-confidence water to
               high-confidence water in the presence of high aerosol
-       aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values: list(int)
+       aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values: list(int)
               HLS Fmask values to convert partial surface water conservative to
-              moderate-confidence water in the presence of high aerosol
-       aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values: list(int)
+              high-confidence water in the presence of high aerosol
+       aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values: list(int)
               HLS Fmask values to convert partial surface water aggressive to
-              moderate-confidence water in the presence of high aerosol
+              high-confidence water in the presence of high aerosol
        shadow_masking_algorithm: str
               Shadow masking algorithm
        min_slope_angle: float
@@ -3756,14 +3756,14 @@ def _populate_dswx_metadata_processing_parameters(
 
     # aerosol metadata fields
     aerosol_metadata_dict = {
-        'aerosol_not_water_to_moderate_conf_water_fmask_values':
-            aerosol_not_water_to_moderate_conf_water_fmask_values,
+        'aerosol_not_water_to_high_conf_water_fmask_values':
+            aerosol_not_water_to_high_conf_water_fmask_values,
         'aerosol_water_moderate_conf_to_high_conf_water_fmask_values':
             aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
-        'aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values':
-            aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values,
-        'aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values':
-            aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values,
+        'aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values':
+            aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
+        'aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values':
+            aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values,
     }
 
     for aerosol_metadata_field_lower, fmask_values in aerosol_metadata_dict.items():
@@ -4220,10 +4220,10 @@ def generate_dswx_layers(input_list,
                          check_ancillary_inputs_coverage=None,
                          apply_ocean_masking=None,
                          apply_aerosol_class_remapping=None,
-                         aerosol_not_water_to_moderate_conf_water_fmask_values=None,
+                         aerosol_not_water_to_high_conf_water_fmask_values=None,
                          aerosol_water_moderate_conf_to_high_conf_water_fmask_values=None,
-                         aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values=None,
-                         aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values=None,
+                         aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values=None,
+                         aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values=None,
                          shadow_masking_algorithm=None,
                          min_slope_angle=None,
                          max_sun_local_inc_angle=None,
@@ -4315,18 +4315,18 @@ def generate_dswx_layers(input_list,
               Apply ocean masking
        apply_aerosol_class_remapping: bool (optional)
               Apply aerosol masking
-       aerosol_not_water_to_moderate_conf_water_fmask_values: list(int) (optional)
-              HLS Fmask values to convert not-water to moderate-confidence water
+       aerosol_not_water_to_high_conf_water_fmask_values: list(int) (optional)
+              HLS Fmask values to convert not-water to high-confidence water
               in the presence of high aerosol
        aerosol_water_moderate_conf_to_high_conf_water_fmask_values: list(int) (optional)
               HLS Fmask values to convert moderate-confidence water to
               high-confidence water in the presence of high aerosol
-       aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values: list(int) (optional)
+       aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values: list(int) (optional)
               HLS Fmask values to convert partial surface water conservative to
-              moderate-confidence water in the presence of high aerosol
-       aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values: list(int) (optional)
+              high-confidence water in the presence of high aerosol
+       aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values: list(int) (optional)
               HLS Fmask values to convert partial surface water aggressive to
-              moderate-confidence water in the presence of high aerosol
+              high-confidence water in the presence of high aerosol
        shadow_masking_algorithm: str (optional)
               Shadow masking algorithm. Choices: "otsu" or "sun_local_inc_angle"
        min_slope_angle: float (optional)
@@ -4354,10 +4354,10 @@ def generate_dswx_layers(input_list,
                                  check_ancillary_inputs_coverage,
                                  apply_ocean_masking,
                                  apply_aerosol_class_remapping,
-                                 aerosol_not_water_to_moderate_conf_water_fmask_values,
+                                 aerosol_not_water_to_high_conf_water_fmask_values,
                                  aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
-                                 aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values,
-                                 aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values,
+                                 aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
+                                 aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values,
                                  shadow_masking_algorithm,
                                  min_slope_angle,
                                  max_sun_local_inc_angle,
@@ -4382,18 +4382,18 @@ def generate_dswx_layers(input_list,
             apply_ocean_masking = runconfig_constants.apply_ocean_masking
         if apply_aerosol_class_remapping is None:
             apply_aerosol_class_remapping = runconfig_constants.apply_aerosol_class_remapping
-        if aerosol_not_water_to_moderate_conf_water_fmask_values is None:
-            aerosol_not_water_to_moderate_conf_water_fmask_values = \
-                runconfig_constants.aerosol_not_water_to_moderate_conf_water_fmask_values
+        if aerosol_not_water_to_high_conf_water_fmask_values is None:
+            aerosol_not_water_to_high_conf_water_fmask_values = \
+                runconfig_constants.aerosol_not_water_to_high_conf_water_fmask_values
         if aerosol_water_moderate_conf_to_high_conf_water_fmask_values is None:
             aerosol_water_moderate_conf_to_high_conf_water_fmask_values = \
                 runconfig_constants.aerosol_water_moderate_conf_to_high_conf_water_fmask_values
-        if aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values is None:
-            aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values = \
-                runconfig_constants.aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values
-        if aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values is None:
-            aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values = \
-                runconfig_constants.aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values
+        if aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values is None:
+            aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values = \
+                runconfig_constants.aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values
+        if aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values is None:
+            aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values = \
+                runconfig_constants.aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values
         if shadow_masking_algorithm is None:
             shadow_masking_algorithm = \
                 runconfig_constants.shadow_masking_algorithm
@@ -4482,8 +4482,8 @@ def generate_dswx_layers(input_list,
     else:
         aerosol_class_remapping_unused_parameters_str = ' (unused)'
     logger.info(
-        f'        not-water to moderate-confidence water Fmask values:' +
-        f' {aerosol_not_water_to_moderate_conf_water_fmask_values}' +
+        f'        not-water to high-confidence water Fmask values:' +
+        f' {aerosol_not_water_to_high_conf_water_fmask_values}' +
         aerosol_class_remapping_unused_parameters_str)
     logger.info(
         f'        moderate confidence water to'
@@ -4492,13 +4492,13 @@ def generate_dswx_layers(input_list,
         aerosol_class_remapping_unused_parameters_str)
     logger.info(
         f'        partial surface water conservative to'
-        f' moderate-confidence water Fmask values:' +
-        f' {aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values}' +
+        f' high-confidence water Fmask values:' +
+        f' {aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values}' +
         aerosol_class_remapping_unused_parameters_str)
     logger.info(
         f'        partial surface water aggressive to'
-        f' moderate-confidence water Fmask values:' +
-        f' {aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values}' +
+        f' high-confidence water Fmask values:' +
+        f' {aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values}' +
         aerosol_class_remapping_unused_parameters_str)
     logger.info(f'    shadow masking algorithm: {shadow_masking_algorithm}')
     if shadow_masking_algorithm == 'otsu':
@@ -4581,14 +4581,14 @@ def generate_dswx_layers(input_list,
 
     _populate_dswx_metadata_processing_parameters(
         dswx_metadata_dict,
-        aerosol_not_water_to_moderate_conf_water_fmask_values =
-            aerosol_not_water_to_moderate_conf_water_fmask_values,
+        aerosol_not_water_to_high_conf_water_fmask_values =
+            aerosol_not_water_to_high_conf_water_fmask_values,
         aerosol_water_moderate_conf_to_high_conf_water_fmask_values =
             aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
-        aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values =
-            aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values,
-        aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values =
-            aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values,
+        aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values =
+            aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
+        aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values =
+            aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values,
         shadow_masking_algorithm=shadow_masking_algorithm,
         min_slope_angle=min_slope_angle,
         max_sun_local_inc_angle=max_sun_local_inc_angle,
@@ -4832,10 +4832,10 @@ def generate_dswx_layers(input_list,
     if apply_aerosol_class_remapping:
         _apply_aerosol_class_remapping(wtr_1_layer,
             preliminary_cloud_layer, fmask,
-            aerosol_not_water_to_moderate_conf_water_fmask_values,
+            aerosol_not_water_to_high_conf_water_fmask_values,
             aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
-            aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values,
-            aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values)
+            aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
+            aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values)
 
     wtr_2_layer = _apply_landcover_and_shadow_masks(
         wtr_1_layer, nir, landcover_mask, shadow_layer,

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -4355,14 +4355,31 @@ def generate_dswx_layers(input_list,
 
     # use floor integer to compute spatial and cloud coverage
     spatial_coverage = int(100 * float(n_valid) / total_number_of_pixels)
-    cloud_coverage = int(100 * float(n_cloud_and_valid) / n_valid)
+    if n_valid == 0:
+        cloud_coverage = 0
+    else:
+        cloud_coverage = int(100 * float(n_cloud_and_valid) / n_valid)
+
+    if ocean_mask is not None:
+        n_not_ocean = np.sum(ocean_mask) 
+    else:
+        n_not_ocean = total_number_of_pixels
+
+    if n_not_ocean == 0:
+        spatial_coverage_after_ocean_masking = 0
+    else:
+        spatial_coverage_after_ocean_masking = int(100 * float(n_valid) / n_not_ocean)
 
     # print spatial and cloud coverage
     logger.info(f'    spatial coverage [%]:  {spatial_coverage}')
+    logger.info(f'    spatial coverage after ocean masking [%]:'
+                f' {spatial_coverage_after_ocean_masking}')
     logger.info(f'    cloud coverage [%]:  {cloud_coverage}')
 
     # update DSWx-HLS metadata dictionary
     dswx_metadata_dict['SPATIAL_COVERAGE'] = spatial_coverage
+    dswx_metadata_dict['SPATIAL_COVERAGE_AFTER_OCEAN_MASKING'] = \
+        spatial_coverage_after_ocean_masking
     dswx_metadata_dict['CLOUD_COVERAGE'] = cloud_coverage
 
     if dem_file is not None:

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1345,24 +1345,24 @@ def _get_interpreted_dswx_ctable(
     if flag_collapse_wtr_classes:
         # Blue - Open water
         dswx_ctable.SetColorEntry(WATER_COLLAPSED_OPEN_WATER,
-                                  (0, 0, 255)) 
-        # Light Blue - Partial surface water
+                                  (0, 0, 255))
+        # Light blue - Partial surface water
         dswx_ctable.SetColorEntry(WATER_COLLAPSED_PARTIAL_SURFACE_WATER,
                                   (180, 213, 244))
     else:
         # Blue - Water (high confidence)
         dswx_ctable.SetColorEntry(WATER_UNCOLLAPSED_HIGH_CONF_CLEAR,
-                                  (0, 0, 255)) 
+                                  (0, 0, 255))
         # Light blue - Water (moderate conf.)
         dswx_ctable.SetColorEntry(WATER_UNCOLLAPSED_MODERATE_CONF_CLEAR,
-                                  (0, 127, 255))
+                                  (95, 127, 255))
         # Dark green - Partial surface water conservative
         dswx_ctable.SetColorEntry(
-            WATER_UNCOLLAPSED_PARTIAL_SURFACE_WATER_CONSERVATIVE_CLEAR, 
+            WATER_UNCOLLAPSED_PARTIAL_SURFACE_WATER_CONSERVATIVE_CLEAR,
                                   (0, 195, 0)) # 225 ok
         # Light green - Partial surface water aggressive
         dswx_ctable.SetColorEntry(
-            WATER_UNCOLLAPSED_PARTIAL_SURFACE_WATER_AGGRESSIVE_CLEAR, 
+            WATER_UNCOLLAPSED_PARTIAL_SURFACE_WATER_AGGRESSIVE_CLEAR,
                                   (150, 255, 150))
 
     # Dark blue - Ocean masked

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1174,8 +1174,8 @@ def _apply_aerosol_class_remapping_wtr1_class(wtr_1_layer,
                             (preliminary_cloud_layer != UINT8_FILL_VALUE)] += 8
 
 
-def _apply_aerosol_class_remapping(wtr_1_layer, fmask,
-        preliminary_cloud_layer,
+def _apply_aerosol_class_remapping(wtr_1_layer,
+        preliminary_cloud_layer, fmask,
         aerosol_not_water_to_moderate_conf_water_fmask_values,
         aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
         aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values,
@@ -1475,7 +1475,6 @@ def _get_cloud_layer_ctable():
     # - Mask snow/ice bit (1)
     # - Mask cloud bit (2)
     # - Class reassignment due to aerosol interpolation errors (3)
-    # rusty ocre / gray green / grayish yellow
 
     # White - Not masked
     mask_ctable.SetColorEntry(0, (255, 255, 255))
@@ -1495,7 +1494,7 @@ def _get_cloud_layer_ctable():
     mask_ctable.SetColorEntry(7, (127, 127, 255))
 
     # Light ocre - Aerosol reassignment ("0xE4CDA7")
-    mask_ctable.SetColorEntry(8, (288, 205, 167))
+    mask_ctable.SetColorEntry(8, (228, 205, 167))
     # Dark gray - Cloud shadow
     mask_ctable.SetColorEntry(9, (64, 64, 64))
     # Cyan - snow/ice

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -2035,8 +2035,11 @@ def _apply_cloud_masking(wtr_2_layer, cloud_layer):
     '''
 
     # If there's cloud shadow/adjacent to cloud/cloud shadow or
-    # cloud, then mark output as WTR_CLOUD_MASKED
-    wtr_layer[cloud_layer != 0] = WTR_CLOUD_MASKED
+    # cloud, and there was no remapping due to high aerosol
+    # bit 3 (value 2**3 = 8),
+    # then mark output as WTR_CLOUD_MASKED
+    wtr_layer[(cloud_layer != 0) &
+              (cloud_layer != 8)] = WTR_CLOUD_MASKED
 
     # If there's snow only (i.e., no cloud/cloud shadow),
     # the mark output as WTR_SNOW_MASKED

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -4576,6 +4576,9 @@ def generate_dswx_layers(input_list,
     preliminary_cloud_layer = _compute_preliminary_cloud_layer(
         fmask, mask_adjacent_to_cloud_mode)
 
+    # compute total number of pixels
+    total_number_of_pixels = length * width
+
     # create ocean mask
     if shoreline_shapefile is not None:
         ocean_mask = _create_ocean_mask(shoreline_shapefile,
@@ -4586,12 +4589,14 @@ def generate_dswx_layers(input_list,
 
         # update valid_array
         valid_array = np.logical_and(valid_array, ocean_mask)
+        n_not_ocean = np.sum(ocean_mask)
+    else:
+        n_not_ocean = total_number_of_pixels
 
     # create variables to compute spatial and cloud coverage
     n_valid = np.sum(valid_array)
     n_cloud_and_valid = np.sum(((preliminary_cloud_layer) != 0) & (valid_array))
     del valid_array
-    total_number_of_pixels = length * width
 
     # use floor integer to compute spatial and cloud coverage
     spatial_coverage = int(100 * float(n_valid) / total_number_of_pixels)
@@ -4599,11 +4604,6 @@ def generate_dswx_layers(input_list,
         cloud_coverage = 0
     else:
         cloud_coverage = int(100 * float(n_cloud_and_valid) / n_valid)
-
-    if ocean_mask is not None:
-        n_not_ocean = np.sum(ocean_mask) 
-    else:
-        n_not_ocean = total_number_of_pixels
 
     if n_not_ocean == 0:
         spatial_coverage_after_ocean_masking = 0

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1781,7 +1781,9 @@ def _add_snow_to_cloud_layer(wtr_2_layer, cloud_layer, fmask,
        wtr_2_layer: numpy.ndarray
             Cloud-unmasked interpreted water layer
        cloud_layer : numpy.ndarray
-            Preliminary cloud mask (without the snow/ice class)
+            Preliminary cloud mask (without the snow/ice class). This array
+            is updated within the function (mutable numpy.ndarray) and returned
+            after the snow/ice class is added to the layer.
        fmask: numpy ndarray
             HLS Fmask
        mask_adjacent_to_cloud_mode: str

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -982,9 +982,8 @@ def create_landcover_mask(copernicus_landcover_file,
     # WorldCover class 80: permanent water bodies
     # WorldCover class 90: herbaceous wetland
     # WorldCover class 95: mangroves
-    water_binary_mask = ((worldcover_array_up_3 == 80) |
-                         (worldcover_array_up_3 == 90) |
-                         (worldcover_array_up_3 == 95)).astype(np.uint8)
+    water_binary_mask = (np.isin(worldcover_array_up_3, [80, 90, 95])).astype(
+        np.uint8)
     water_aggregate_sum = decimate_by_summation(water_binary_mask,
                                               size_y, size_x)
     del water_binary_mask
@@ -1221,7 +1220,7 @@ def _apply_aerosol_class_remapping(wtr_1_layer, nir,
            high-confidence water in the presence of high aerosol
     """
 
-    # add a not here that nothing changes for high-confidence water
+    # Note: high-confidence water does not need to be changed
     wtr1_class_fmask_values_dict = {
         WATER_NOT_WATER_CLEAR:
             (aerosol_not_water_to_high_conf_water_fmask_values,
@@ -1701,6 +1700,14 @@ def _get_confidence_layer(wtr_2_layer, cloud_layer):
     5: Cloud and cloud shadow
     6: Cloud and snow/ice
     7: Cloud, cloud shadow, and snow/ice
+    8: Aerosol remapped
+    9: Aerosol remapped and cloud shadow
+    10: Aerosol remapped and snow/ice
+    11: Aerosol remapped, cloud shadow and snow/ice
+    12: Aerosol remapped and cloud
+    13: Aerosol remapped, cloud, and cloud shadow
+    14: Aerosol remapped, cloud ,and snow/ice
+    15: Aerosol remapped, cloud, cloud shadow, and snow/ice
     255: Fill value (no data)
     The cloud classification in the CONF layer represents
     the ensemble of cloud, cloud shadow, or adjacent-to-cloud
@@ -1717,18 +1724,8 @@ def _get_confidence_layer(wtr_2_layer, cloud_layer):
     conf_layer = wtr_2_layer.copy()
 
     # Update the pixels with cloud and/or cloud shadow
-    cloud_idx = ((cloud_layer == 1) | 
-                 (cloud_layer == 3) |
-                 (cloud_layer == 4) |
-                 (cloud_layer == 5) |
-                 (cloud_layer == 6) |
-                 (cloud_layer == 7) |
-                 (cloud_layer == 9) | 
-                 (cloud_layer == 11) |
-                 (cloud_layer == 12) |
-                 (cloud_layer == 13) |
-                 (cloud_layer == 14) |
-                 (cloud_layer == 15))
+    cloud_idx = np.isin(cloud_layer, [1, 3, 4, 5, 6, 7,
+                                      9, 11, 12, 13, 14, 15])
 
     idx = ((conf_layer == WATER_NOT_WATER_CLEAR) & cloud_idx)
     conf_layer[idx] = WATER_NOT_WATER_CLOUD

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -3573,8 +3573,11 @@ def _populate_dswx_metadata_processing_parameters(
         mask_adjacent_to_cloud_mode
 
     # Copernicus class for forest masking
-    dswx_metadata_dict['FOREST_MASK_LANDCOVER_CLASSES'] = \
-        ','.join([str(c) for c in forest_mask_landcover_classes])
+    if forest_mask_landcover_classes:
+        dswx_metadata_dict['FOREST_MASK_LANDCOVER_CLASSES'] = \
+            ','.join([str(c) for c in forest_mask_landcover_classes])
+    else:
+        dswx_metadata_dict['FOREST_MASK_LANDCOVER_CLASSES'] = '-'
 
     # ocean masking distance from shoreline in km
     if shoreline_shapefile:

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -33,7 +33,7 @@ FLAG_CLIP_NEGATIVE_REFLECTANCE = True
 landcover_mask_type = 'standard'
 
 
-# HLS thresholds are evaluated over unscalled reflactance values
+# HLS thresholds are evaluated over unscaled reflactance values
 SCALE_FACTOR = 0.0001
 AEROSOL_REMAPPING_MAX_NIR = 0.1 / SCALE_FACTOR
 
@@ -1230,16 +1230,16 @@ def _apply_aerosol_class_remapping(wtr_1_layer, nir,
     wtr1_class_fmask_values_dict = {
         WATER_NOT_WATER_CLEAR:
             (aerosol_not_water_to_high_conf_water_fmask_values,
-             WATER_UNCOLLAPSED_MODERATE_CONF_CLEAR),
+             WATER_UNCOLLAPSED_HIGH_CONF_CLEAR),
         WATER_UNCOLLAPSED_MODERATE_CONF_CLEAR:
             (aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
              WATER_UNCOLLAPSED_HIGH_CONF_CLEAR),
         WATER_UNCOLLAPSED_PARTIAL_SURFACE_WATER_CONSERVATIVE_CLEAR:
             (aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
-             WATER_UNCOLLAPSED_MODERATE_CONF_CLEAR),
+             WATER_UNCOLLAPSED_HIGH_CONF_CLEAR),
         WATER_UNCOLLAPSED_PARTIAL_SURFACE_WATER_AGGRESSIVE_CLEAR:
             (aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values,
-             WATER_UNCOLLAPSED_MODERATE_CONF_CLEAR)
+             WATER_UNCOLLAPSED_HIGH_CONF_CLEAR)
         }
 
     for input_wtr1_class, (fmask_values, output_wtr1_class) in \

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1170,8 +1170,10 @@ def _apply_aerosol_class_remapping_wtr1_class(wtr_1_layer,
     wtr_1_layer[to_mask_array] = output_wtr1_class
 
     # set CLOUD layer bit (3): 2**3 = 8
-    preliminary_cloud_layer[(to_mask_array) &
-                            (preliminary_cloud_layer != UINT8_FILL_VALUE)] += 8
+    ind = np.where((to_mask_array) &
+                   (preliminary_cloud_layer != UINT8_FILL_VALUE))
+    preliminary_cloud_layer[ind] = np.bitwise_or(
+        preliminary_cloud_layer[ind], 2**3)
 
 
 def _apply_aerosol_class_remapping(wtr_1_layer,

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -33,7 +33,7 @@ FLAG_CLIP_NEGATIVE_REFLECTANCE = True
 landcover_mask_type = 'standard'
 
 
-# HLS thresholds are evaluated over unscaled reflactance values
+# HLS thresholds are evaluated over unscaled reflectance values
 SCALE_FACTOR = 0.0001
 AEROSOL_REMAPPING_MAX_NIR = 0.1 / SCALE_FACTOR
 

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -3677,7 +3677,7 @@ def _populate_dswx_metadata_datasets(dswx_metadata_dict,
         dswx_metadata_dict['DEM_SOURCE'] = \
             os.path.basename(dem_file)
     else:
-        dswx_metadata_dict['DEM_SOURCE'] = '(not provided)'
+        dswx_metadata_dict['DEM_SOURCE'] = '-'
 
     if landcover_file_description:
         dswx_metadata_dict['LANDCOVER_SOURCE'] = landcover_file_description
@@ -3685,7 +3685,7 @@ def _populate_dswx_metadata_datasets(dswx_metadata_dict,
         dswx_metadata_dict['LANDCOVER_SOURCE'] = \
             os.path.basename(landcover_file)
     else:
-        dswx_metadata_dict['LANDCOVER_SOURCE'] = '(not provided)'
+        dswx_metadata_dict['LANDCOVER_SOURCE'] = '-'
 
     if worldcover_file_description:
         dswx_metadata_dict['WORLDCOVER_SOURCE'] = worldcover_file_description
@@ -3693,7 +3693,7 @@ def _populate_dswx_metadata_datasets(dswx_metadata_dict,
         dswx_metadata_dict['WORLDCOVER_SOURCE'] = \
             os.path.basename(worldcover_file)
     else:
-        dswx_metadata_dict['WORLDCOVER_SOURCE'] = '(not provided)'
+        dswx_metadata_dict['WORLDCOVER_SOURCE'] = '-'
 
     if shoreline_shapefile_description:
         dswx_metadata_dict['SHORELINE_SOURCE'] = \
@@ -3702,7 +3702,7 @@ def _populate_dswx_metadata_datasets(dswx_metadata_dict,
         dswx_metadata_dict['SHORELINE_SOURCE'] = \
             os.path.basename(shoreline_shapefile)
     else:
-        dswx_metadata_dict['SHORELINE_SOURCE'] = '(not provided)'
+        dswx_metadata_dict['SHORELINE_SOURCE'] = '-'
 
 
 def _populate_dswx_metadata_processing_parameters(
@@ -4470,6 +4470,9 @@ def generate_dswx_layers(input_list,
     logger.info(f'        ocean masking distance from shoreline in km:'
                 f' {ocean_masking_shoreline_distance_km}'
                 f'{ocean_masking_unused_parameters_str}')
+    if not apply_ocean_masking:
+        shoreline_shapefile = None
+        shoreline_shapefile_description = None
 
     logger.info(f'    apply aerosol water class remapping:'
                 f' {apply_aerosol_class_remapping}')

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -4347,7 +4347,7 @@ def generate_dswx_layers(input_list,
             check_ancillary_inputs_coverage = \
                 runconfig_constants.check_ancillary_inputs_coverage
         if apply_aerosol_class_remapping is None:
-            apply_aerosol_class_remapping = runconfig.constants.apply_aerosol_class_remapping
+            apply_aerosol_class_remapping = runconfig_constants.apply_aerosol_class_remapping
         if aerosol_not_water_to_moderate_conf_water_fmask_values is None:
             aerosol_not_water_to_moderate_conf_water_fmask_values = \
                 runconfig_constants.aerosol_not_water_to_moderate_conf_water_fmask_values

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1160,7 +1160,7 @@ def _apply_aerosol_class_remapping_single_class(wtr_1_layer, nir,
        wtr_1_layer: numpy.ndarray
             Interpreted layer (WTR-1) (mutable numpy.ndarray)
        nir: numpy.ndarray
-              Near infrared (NIR) channel
+            Near infrared (NIR) channel
        preliminary_cloud_layer : numpy.ndarray
             Preliminary cloud mask aerosol remapping bit (mutable
             numpy.ndarray)
@@ -1200,7 +1200,7 @@ def _apply_aerosol_class_remapping(wtr_1_layer, nir,
        wtr_1_layer: numpy.ndarray
             Interpreted layer (WTR-1) (mutable numpy.ndarray)
        nir: numpy.ndarray
-              Near infrared (NIR) channel
+            Near infrared (NIR) channel
        preliminary_cloud_layer : numpy.ndarray
             Preliminary cloud mask aerosol remapping bit (mutable
             numpy.ndarray)
@@ -1888,10 +1888,10 @@ def _compute_preliminary_cloud_layer(fmask, mask_adjacent_to_cloud_mode):
 
        See Also
        ---------
-            _add_snow_to_cloud_layer : Add the snow bit encodings from `fmask` to
+       _add_snow_to_cloud_layer : Add the snow bit encodings from `fmask` to
             `preliminary_cloud_layer`
-            _apply_aerosol_class_remapping: Add bit indicating class
-                reassignment due to aerosol interpolation errors
+       _apply_aerosol_class_remapping: Add bit indicating class
+            reassignment due to aerosol interpolation errors
     """
     preliminary_cloud_layer = np.zeros(fmask.shape, dtype = np.uint8)
 
@@ -4860,11 +4860,11 @@ def generate_dswx_layers(input_list,
                           flag_collapse_wtr_classes=FLAG_COLLAPSE_WTR_CLASSES,
                           output_files_list=build_vrt_list)
 
-    cloud = _add_snow_to_cloud_layer(
+    cloud_layer = _add_snow_to_cloud_layer(
         wtr_2_layer, preliminary_cloud_layer, fmask,
         mask_adjacent_to_cloud_mode)
 
-    wtr_layer = _apply_cloud_masking(wtr_2_layer, cloud)
+    wtr_layer = _apply_cloud_masking(wtr_2_layer, cloud_layer)
 
     if output_interpreted_band:
         save_dswx_product(wtr_layer, 'WTR',
@@ -4930,11 +4930,11 @@ def generate_dswx_layers(input_list,
         output_files_list += [output_browse_image]
 
     if output_cloud_layer:
-        save_cloud_layer(cloud, output_cloud_layer, dswx_metadata_dict, geotransform,
-                        projection,
-                        description=band_description_dict['CLOUD'],
-                        scratch_dir=scratch_dir,
-                        output_files_list=build_vrt_list)
+        save_cloud_layer(cloud_layer, output_cloud_layer, dswx_metadata_dict,
+                         geotransform, projection,
+                         description=band_description_dict['CLOUD'],
+                         scratch_dir=scratch_dir,
+                         output_files_list=build_vrt_list)
 
     binary_water_layer = _get_binary_water_layer(wtr_layer)
     if output_binary_water:
@@ -4947,7 +4947,7 @@ def generate_dswx_layers(input_list,
 
     if output_confidence_layer:
         confidence_layer = _get_confidence_layer(wtr_2_layer=wtr_2_layer,
-                                                 cloud_layer=cloud)
+                                                 cloud_layer=cloud_layer)
         confidence_layer_ctable = _get_confidence_layer_ctable()
         _save_array(confidence_layer,
                     output_confidence_layer,
@@ -4972,7 +4972,7 @@ def generate_dswx_layers(input_list,
                           wtr_2=wtr_2_layer,
                           land=landcover_mask,
                           shad=shadow_layer,
-                          cloud=cloud,
+                          cloud=cloud_layer,
                           dem=dem,
                           scratch_dir=scratch_dir,
                           output_files_list=output_files_list)

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1697,8 +1697,7 @@ def _compute_diagnostic_tests(blue, green, red, nir, swir1, swir2,
 def _compute_preliminary_cloud_layer(fmask, mask_adjacent_to_cloud_mode):
     """Compute a preliminary CLOUD layer without the snow/ice
        class. The CLOUD layer will be completed by a subsequent function
-       _add_snow_to_cloud_layer_and_apply_cloud_masking()
-       after the WTR-2 layer is generated.
+       _add_snow_to_cloud_layer().
 
        Parameters
        ----------
@@ -1710,13 +1709,21 @@ def _compute_preliminary_cloud_layer(fmask, mask_adjacent_to_cloud_mode):
             shadow (default); "ignore" - ignore the adjacent to cloud/
             cloud shadow classification; and 'cover' - covers these areas
             with a dilation algorithm (this option will be handled in
-            the subsequent function
-            _add_snow_to_cloud_layer_and_apply_cloud_masking())
+            the subsequent function _add_snow_to_cloud_layer())
 
        Returns
        -------
-       preliminary_cloud_layer : numpy.ndarray
             Preliminary cloud mask (without the snow/ice class)
+            with dtype of uint8 and values assigned as follows:
+                0: Not masked
+                1: Cloud shadow or adjacent to cloud/cloud shadow
+                4: Cloud
+                5: Cloud and class 1 (cloud shadow or adjacent to cloud/cloud shadow)
+                255: Fill value (no data)
+       See Also
+       ---------
+       _add_snow_to_cloud_layer : Add the snow bit encodings from `fmask` to
+       `preliminary_cloud_layer`
     """
     preliminary_cloud_layer = np.zeros(fmask.shape, dtype = np.uint8)
 
@@ -1730,7 +1737,7 @@ def _compute_preliminary_cloud_layer(fmask, mask_adjacent_to_cloud_mode):
          else: ignore this class)
     (*) 3 - Cloud shadow (output bit 0)
         4 - Snow/ice (output bit 1, will be assigned in the subsequent function:
-            _add_snow_to_cloud_layer_and_apply_cloud_masking())
+            _add_snow_to_cloud_layer())
         5 - Water
         6-7 - Aerosol quality:
               00 - Climatology aerosol
@@ -1766,7 +1773,6 @@ def _add_snow_to_cloud_layer(wtr_2_layer, cloud_layer, fmask,
     """Finish computing the CLOUD layer by adding the snow/ice class
        to the CLOUD layer.
        This function succeeds the function _compute_preliminary_cloud_layer()
-       and preceeds _apply_cloud_masking()
 
        Parameters
        ----------

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -4249,6 +4249,7 @@ def generate_dswx_layers(input_list,
     width = image_dict['width']
     invalid_ind = np.where(image_dict['invalid_ind_array'])
     valid_array = ~image_dict['invalid_ind_array']
+    del image_dict
 
     sun_azimuth_angle_meta = dswx_metadata_dict['MEAN_SUN_AZIMUTH_ANGLE'].split(', ')
     sun_zenith_angle_meta = dswx_metadata_dict['MEAN_SUN_ZENITH_ANGLE'].split(', ')

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -4257,6 +4257,12 @@ def generate_dswx_layers(input_list,
     logger.info(f'    mean azimuth angle: {sun_azimuth_angle}')
     logger.info(f'    mean elevation angle: {sun_elevation_angle}')
 
+    # check ancillary inputs
+    if check_ancillary_inputs_coverage:
+        _check_ancillary_inputs(dem_file, landcover_file, worldcover_file,
+                                shoreline_shapefile, geotransform,
+                                projection, length, width)
+
     # print input HLS product spatial and cloud coverage
     logger.info(f'data coverage:')
     if 'INPUT_HLS_PRODUCT_SPATIAL_COVERAGE' in dswx_metadata_dict.keys():
@@ -4304,11 +4310,6 @@ def generate_dswx_layers(input_list,
     dswx_metadata_dict['SPATIAL_COVERAGE'] = spatial_coverage
     dswx_metadata_dict['CLOUD_COVERAGE'] = cloud_coverage
 
-    # check ancillary inputs
-    if check_ancillary_inputs_coverage:
-        _check_ancillary_inputs(dem_file, landcover_file, worldcover_file,
-                                shoreline_shapefile, geotransform,
-                                projection, length, width)
 
     if dem_file is not None:
         # DEM

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1863,7 +1863,7 @@ def _apply_cloud_masking(wtr_2_layer, cloud_layer):
        wtr_layer : numpy.ndarray
               Cloud-masked interpreted water layer
     """
-    wtr_layer = np.zeros_like(wtr_2_layer)
+    wtr_layer = wtr_2_layer.copy()
 
     '''
     Cloud layer:

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -228,9 +228,7 @@ layer_names_to_args_dict = {
     'INFRARED_RGB': 'output_infrared_rgb_file'}
 
 
-METADATA_FIELDS_TO_COPY_FROM_HLS_LIST = ['SPATIAL_COVERAGE',
-                                         'CLOUD_COVERAGE',
-                                         'MEAN_SUN_AZIMUTH_ANGLE',
+METADATA_FIELDS_TO_COPY_FROM_HLS_LIST = ['MEAN_SUN_AZIMUTH_ANGLE',
                                          'MEAN_SUN_ZENITH_ANGLE',
                                          'MEAN_VIEW_AZIMUTH_ANGLE',
                                          'MEAN_VIEW_ZENITH_ANGLE',
@@ -1907,6 +1905,9 @@ def _load_hls_band_from_file(filename, image_dict, offset_dict, scale_dict,
         for k, v in metadata.items():
             if k.upper() in METADATA_FIELDS_TO_COPY_FROM_HLS_LIST:
                 dswx_metadata_dict[k.upper()] = v
+            elif k.upper() in ['SPATIAL_COVERAGE', 'CLOUD_COVERAGE']:
+                dswx_metadata_key = 'INPUT_HLS_PRODUCT_'+k.upper()
+                dswx_metadata_dict[dswx_metadata_key] = v
             elif (k.upper() == 'LANDSAT_PRODUCT_ID' or
                     k.upper() == 'PRODUCT_URI'):
                 dswx_metadata_dict['SENSOR_PRODUCT_ID'] = v
@@ -4198,6 +4199,13 @@ def generate_dswx_layers(input_list,
     sun_azimuth_angle_meta = dswx_metadata_dict['MEAN_SUN_AZIMUTH_ANGLE'].split(', ')
     sun_zenith_angle_meta = dswx_metadata_dict['MEAN_SUN_ZENITH_ANGLE'].split(', ')
 
+    if 'INPUT_HLS_PRODUCT_SPATIAL_COVERAGE' in dswx_metadata_dict.keys():
+        hls_product_spatial_coverage = dswx_metadata_dict[
+            'INPUT_HLS_PRODUCT_SPATIAL_COVERAGE']
+    if 'INPUT_HLS_PRODUCT_CLOUD_COVERAGE' in dswx_metadata_dict.keys():
+        hls_product_cloud_coverage = dswx_metadata_dict[
+            'INPUT_HLS_PRODUCT_CLOUD_COVERAGE']
+
     if len(sun_azimuth_angle_meta) == 2:
         sun_azimuth_angle = (float(sun_azimuth_angle_meta[0]) +
                             float(sun_azimuth_angle_meta[1])) / 2.0
@@ -4215,6 +4223,12 @@ def generate_dswx_layers(input_list,
     logger.info(f'Sun parameters (from HLS metadata):')
     logger.info(f'    mean azimuth angle: {sun_azimuth_angle}')
     logger.info(f'    mean elevation angle: {sun_elevation_angle}')
+
+    logger.info(f'Data coverage:')
+    logger.info(f'    Input HLS product spatial coverage [%]:'
+                f' {hls_product_spatial_coverage}')
+    logger.info(f'    Input HLS product cloud coverage [%]:'
+                f' {hls_product_cloud_coverage}')
 
     # check ancillary inputs
     if check_ancillary_inputs_coverage:

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1713,17 +1713,19 @@ def _compute_preliminary_cloud_layer(fmask, mask_adjacent_to_cloud_mode):
 
        Returns
        -------
-            Preliminary cloud mask (without the snow/ice class)
-            with dtype of uint8 and values assigned as follows:
+            preliminary_cloud_layer : numpy.ndarray
+                Preliminary cloud mask (without the snow/ice class)
+                with dtype of uint8 and values assigned as follows:
                 0: Not masked
                 1: Cloud shadow or adjacent to cloud/cloud shadow
                 4: Cloud
                 5: Cloud and class 1 (cloud shadow or adjacent to cloud/cloud shadow)
                 255: Fill value (no data)
+
        See Also
        ---------
-       _add_snow_to_cloud_layer : Add the snow bit encodings from `fmask` to
-       `preliminary_cloud_layer`
+            _add_snow_to_cloud_layer : Add the snow bit encodings from `fmask` to
+            `preliminary_cloud_layer`
     """
     preliminary_cloud_layer = np.zeros(fmask.shape, dtype = np.uint8)
 
@@ -1792,20 +1794,21 @@ def _add_snow_to_cloud_layer(wtr_2_layer, cloud_layer, fmask,
        Returns
        -------
        cloud_layer : numpy.ndarray
-            Cloud mask (without the snow/ice class)
-            with dtype of uint8 and values assigned as follows:
-        0: Not masked
-        1: Cloud shadow or adjacent to cloud/cloud shadow
-        2: Snow/ice
-        3: Snow/ice and class 1 (cloud shadow or adjacent to cloud/cloud
-        shadow)
-        4: Cloud
-        5: Cloud and class 1 (cloud shadow or adjacent to cloud/cloud
-        shadow)
-        6: Cloud and snow/ice
-        7: Cloud, snow/ice, and class 1 (cloud shadow or adjacent to
-        cloud/cloud shadow)
-        255: Fill value (no data)
+            Cloud mask (without the snow/ice class) with dtype of uint8 and
+            values assigned as follows:
+
+            0: Not masked
+            1: Cloud shadow or adjacent to cloud/cloud shadow
+            2: Snow/ice
+            3: Snow/ice and class 1 (cloud shadow or adjacent to cloud/cloud
+                shadow)
+            4: Cloud
+            5: Cloud and class 1 (cloud shadow or adjacent to cloud/cloud
+                shadow)
+            6: Cloud and snow/ice
+            7: Cloud, snow/ice, and class 1 (cloud shadow or adjacent to
+                cloud/cloud shadow)
+            255: Fill value (no data)
 
     """
 

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1496,9 +1496,7 @@ def _get_cloud_layer_ctable():
     mask_ctable.SetColorEntry(7, (127, 127, 255))
 
     # Light ocre - Aerosol reassignment ("0xE4CDA7")
-    # mask_ctable.SetColorEntry(8, (228, 205, 167))
-    # Grayish blue - Aerosol reassignment ("0x7393B3")
-    mask_ctable.SetColorEntry(8, (115, 147, 179))
+    mask_ctable.SetColorEntry(8, (228, 205, 167))
     # Dark gray - Cloud shadow
     mask_ctable.SetColorEntry(9, (64, 64, 64))
     # Cyan - snow/ice

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1792,8 +1792,21 @@ def _add_snow_to_cloud_layer(wtr_2_layer, cloud_layer, fmask,
        Returns
        -------
        cloud_layer : numpy.ndarray
-              Cloud mask
-    
+            Cloud mask (without the snow/ice class)
+            with dtype of uint8 and values assigned as follows:
+        0: Not masked
+        1: Cloud shadow or adjacent to cloud/cloud shadow
+        2: Snow/ice
+        3: Snow/ice and class 1 (cloud shadow or adjacent to cloud/cloud
+        shadow)
+        4: Cloud
+        5: Cloud and class 1 (cloud shadow or adjacent to cloud/cloud
+        shadow)
+        6: Cloud and snow/ice
+        7: Cloud, snow/ice, and class 1 (cloud shadow or adjacent to
+        cloud/cloud shadow)
+        255: Fill value (no data)
+
     """
 
     '''

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -3484,7 +3484,7 @@ def _populate_dswx_metadata_processing_parameters(
 
     # Copernicus class for forest masking
     dswx_metadata_dict['FOREST_MASK_LANDCOVER_CLASSES'] = \
-        ', '.join(forest_mask_landcover_classes)
+        ','.join([str(c) for c in forest_mask_landcover_classes])
 
     # ocean masking distance from shoreline in km
     dswx_metadata_dict['OCEAN_MASKING_SHORELINE_DISTANCE_KM'] = \
@@ -4174,7 +4174,7 @@ def generate_dswx_layers(input_list,
         dswx_metadata_dict,
         shadow_masking_algorithm=shadow_masking_algorithm,
         min_slope_angle=min_slope_angle,
-        max_sun_local_inc_angle=max_sun_local_inc_angle=,
+        max_sun_local_inc_angle=max_sun_local_inc_angle,
         mask_adjacent_to_cloud_mode=mask_adjacent_to_cloud_mode,
         forest_mask_landcover_classes=forest_mask_landcover_classes,
         ocean_masking_shoreline_distance_km =

--- a/src/proteus/schemas/dswx_hls.yaml
+++ b/src/proteus/schemas/dswx_hls.yaml
@@ -70,7 +70,7 @@ runconfig:
             # Apply ocean masking
             apply_ocean_masking: bool(required=False)
 
-            # Apply aeresol masking
+            # Apply aeresol class remapping
             apply_aerosol_class_remapping: bool(required=False)
 
             # HLS Fmask values to convert not-water to high-confidence water

--- a/src/proteus/schemas/dswx_hls.yaml
+++ b/src/proteus/schemas/dswx_hls.yaml
@@ -68,23 +68,23 @@ runconfig:
             check_ancillary_inputs_coverage: bool(required=False)
 
             # Apply aeresol masking
-            apply_aerosol_masking: bool(required=False)
+            apply_aerosol_class_remapping: bool(required=False)
 
-            # HLS Fmask values to convert not-water to high-confidence water
+            # HLS Fmask values to convert not-water to moderate-confidence water
             # in the presence of high aerosol
-            aerosol_not_water_to_high_conf_water_fmask_values: list(int(), min=0, required=False)
+            aerosol_not_water_to_moderate_conf_water_fmask_values: list(int(), min=0, required=False)
 
             # HLS Fmask values to convert moderate-confidence water to
             # high-confidence water in the presence of high aerosol
             aerosol_water_moderate_conf_to_high_conf_water_fmask_values: list(int(), min=0, required=False)
 
             # HLS Fmask values to convert partial surface water conservative to
-            # high-confidence water in the presence of high aerosol
-            aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values: list(int(), min=0, required=False)
+            # moderate-confidence water in the presence of high aerosol
+            aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values: list(int(), min=0, required=False)
 
             # HLS Fmask values to convert partial surface water aggressive to
-            # high-confidence water in the presence of high aerosol
-            aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values: list(int(), min=0, required=False)
+            # moderate-confidence water in the presence of high aerosol
+            aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values: list(int(), min=0, required=False)
 
             # Select shadow masking algorithm
             shadow_masking_algorithm: enum('otsu', 'sun_local_inc_angle', required=False)

--- a/src/proteus/schemas/dswx_hls.yaml
+++ b/src/proteus/schemas/dswx_hls.yaml
@@ -67,6 +67,9 @@ runconfig:
             # Check if ancillary inputs cover entirely the output product
             check_ancillary_inputs_coverage: bool(required=False)
 
+            # Apply aeresol masking
+            apply_aerosol_masking: bool(required=False)
+
             # HLS Fmask values to convert not-water to high-confidence water
             # in the presence of high aerosol
             aerosol_not_water_to_high_conf_water_fmask_values: list(int(), min=0, required=False)

--- a/src/proteus/schemas/dswx_hls.yaml
+++ b/src/proteus/schemas/dswx_hls.yaml
@@ -67,6 +67,22 @@ runconfig:
             # Check if ancillary inputs cover entirely the output product
             check_ancillary_inputs_coverage: bool(required=False)
 
+            # HLS Fmask values to convert not-water to high-confidence water
+            # in the presence of high aerosol
+            aerosol_not_water_to_high_conf_water_fmask_values: list(int(), min=0, required=False)
+
+            # HLS Fmask values to convert moderate-confidence water to
+            # high-confidence water in the presence of high aerosol
+            aerosol_water_moderate_conf_to_high_conf_water_fmask_values: list(int(), min=0, required=False)
+
+            # HLS Fmask values to convert partial surface water conservative to
+            # high-confidence water in the presence of high aerosol
+            aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values: list(int(), min=0, required=False)
+
+            # HLS Fmask values to convert partial surface water aggressive to
+            # high-confidence water in the presence of high aerosol
+            aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values: list(int(), min=0, required=False)
+
             # Select shadow masking algorithm
             shadow_masking_algorithm: enum('otsu', 'sun_local_inc_angle', required=False)
 

--- a/src/proteus/schemas/dswx_hls.yaml
+++ b/src/proteus/schemas/dswx_hls.yaml
@@ -67,6 +67,9 @@ runconfig:
             # Check if ancillary inputs cover entirely the output product
             check_ancillary_inputs_coverage: bool(required=False)
 
+            # Apply ocean masking
+            apply_ocean_masking: bool(required=False)
+
             # Apply aeresol masking
             apply_aerosol_class_remapping: bool(required=False)
 

--- a/src/proteus/schemas/dswx_hls.yaml
+++ b/src/proteus/schemas/dswx_hls.yaml
@@ -73,21 +73,21 @@ runconfig:
             # Apply aeresol masking
             apply_aerosol_class_remapping: bool(required=False)
 
-            # HLS Fmask values to convert not-water to moderate-confidence water
+            # HLS Fmask values to convert not-water to high-confidence water
             # in the presence of high aerosol
-            aerosol_not_water_to_moderate_conf_water_fmask_values: list(int(), min=0, required=False)
+            aerosol_not_water_to_high_conf_water_fmask_values: list(int(), min=0, required=False)
 
             # HLS Fmask values to convert moderate-confidence water to
             # high-confidence water in the presence of high aerosol
             aerosol_water_moderate_conf_to_high_conf_water_fmask_values: list(int(), min=0, required=False)
 
             # HLS Fmask values to convert partial surface water conservative to
-            # moderate-confidence water in the presence of high aerosol
-            aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values: list(int(), min=0, required=False)
+            # high-confidence water in the presence of high aerosol
+            aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values: list(int(), min=0, required=False)
 
             # HLS Fmask values to convert partial surface water aggressive to
-            # moderate-confidence water in the presence of high aerosol
-            aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values: list(int(), min=0, required=False)
+            # high-confidence water in the presence of high aerosol
+            aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values: list(int(), min=0, required=False)
 
             # Select shadow masking algorithm
             shadow_masking_algorithm: enum('otsu', 'sun_local_inc_angle', required=False)

--- a/src/proteus/schemas/dswx_hls.yaml
+++ b/src/proteus/schemas/dswx_hls.yaml
@@ -79,8 +79,10 @@ runconfig:
             # Define how areas adjacent to cloud/cloud-shadow should be handled
             mask_adjacent_to_cloud_mode: enum('mask', 'ignore', 'cover', required=False)
 
-            # Copernicus CGLS Land Cover 100m forest classes
-            copernicus_forest_classes: list(int(), min=0, required=False)
+            # Copernicus CGLS Land Cover 100m forest classes to mask out from
+            # the WTR-2 and WTR layer due to dark reflectance that is usually
+            # misinterpreted as water.
+            forest_mask_landcover_classes: list(int(), min=0, required=False)
 
             # Ocean masking distance from shoreline in km
             ocean_masking_shoreline_distance_km: num(required=False)

--- a/src/proteus/version.py
+++ b/src/proteus/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.5.3'
+VERSION = '1.0.0'

--- a/tests/test_dswx_hls_workflow.py
+++ b/tests/test_dswx_hls_workflow.py
@@ -94,7 +94,7 @@ def test_workflow():
         min_slope_angle = args.min_slope_angle,
         max_sun_local_inc_angle=args.max_sun_local_inc_angle,
         mask_adjacent_to_cloud_mode=args.mask_adjacent_to_cloud_mode,
-        copernicus_forest_classes=args.copernicus_forest_classes,
+        forest_mask_landcover_classes=args.forest_mask_landcover_classes,
         ocean_masking_shoreline_distance_km = \
             args.ocean_masking_shoreline_distance_km,
         flag_debug=args.flag_debug)

--- a/tests/test_dswx_hls_workflow.py
+++ b/tests/test_dswx_hls_workflow.py
@@ -90,6 +90,8 @@ def test_workflow():
         scratch_dir=args.scratch_dir,
         product_id=args.product_id,
         product_version=args.product_version,
+        check_ancillary_inputs_coverage=args.check_ancillary_inputs_coverage,
+        apply_aerosol_masking=args.apply_aerosol_masking,
         aerosol_not_water_to_high_conf_water_fmask_values =
             args.aerosol_not_water_to_high_conf_water_fmask_values,
         aerosol_water_moderate_conf_to_high_conf_water_fmask_values =

--- a/tests/test_dswx_hls_workflow.py
+++ b/tests/test_dswx_hls_workflow.py
@@ -92,14 +92,14 @@ def test_workflow():
         product_version=args.product_version,
         check_ancillary_inputs_coverage=args.check_ancillary_inputs_coverage,
         apply_aerosol_class_remapping=args.apply_aerosol_class_remapping,
-        aerosol_not_water_to_moderate_conf_water_fmask_values =
-            args.aerosol_not_water_to_moderate_conf_water_fmask_values,
+        aerosol_not_water_to_high_conf_water_fmask_values =
+            args.aerosol_not_water_to_high_conf_water_fmask_values,
         aerosol_water_moderate_conf_to_high_conf_water_fmask_values =
             args.aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
-        aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values =
-            args.aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values,
-        aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values =
-            args.aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values,
+        aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values =
+            args.aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
+        aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values =
+            args.aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values,
         shadow_masking_algorithm=args.shadow_masking_algorithm,
         min_slope_angle = args.min_slope_angle,
         max_sun_local_inc_angle=args.max_sun_local_inc_angle,

--- a/tests/test_dswx_hls_workflow.py
+++ b/tests/test_dswx_hls_workflow.py
@@ -91,15 +91,15 @@ def test_workflow():
         product_id=args.product_id,
         product_version=args.product_version,
         check_ancillary_inputs_coverage=args.check_ancillary_inputs_coverage,
-        apply_aerosol_masking=args.apply_aerosol_masking,
-        aerosol_not_water_to_high_conf_water_fmask_values =
-            args.aerosol_not_water_to_high_conf_water_fmask_values,
+        apply_aerosol_class_remapping=args.apply_aerosol_class_remapping,
+        aerosol_not_water_to_moderate_conf_water_fmask_values =
+            args.aerosol_not_water_to_moderate_conf_water_fmask_values,
         aerosol_water_moderate_conf_to_high_conf_water_fmask_values =
             args.aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
-        aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values =
-            args.aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
-        aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values =
-            args.aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values,
+        aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values =
+            args.aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values,
+        aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values =
+            args.aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values,
         shadow_masking_algorithm=args.shadow_masking_algorithm,
         min_slope_angle = args.min_slope_angle,
         max_sun_local_inc_angle=args.max_sun_local_inc_angle,

--- a/tests/test_dswx_hls_workflow.py
+++ b/tests/test_dswx_hls_workflow.py
@@ -90,6 +90,14 @@ def test_workflow():
         scratch_dir=args.scratch_dir,
         product_id=args.product_id,
         product_version=args.product_version,
+        aerosol_not_water_to_high_conf_water_fmask_values =
+            args.aerosol_not_water_to_high_conf_water_fmask_values,
+        aerosol_water_moderate_conf_to_high_conf_water_fmask_values =
+            args.aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
+        aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values =
+            args.aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
+        aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values =
+            args.aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values,
         shadow_masking_algorithm=args.shadow_masking_algorithm,
         min_slope_angle = args.min_slope_angle,
         max_sun_local_inc_angle=args.max_sun_local_inc_angle,


### PR DESCRIPTION
This PR updates proteus for release v1.0. Changes:
- Rename metadata fields imported from HLS product from `SPATIAL_COVERAGE` and `CLOUD_COVERAGE` to `INPUT_HLS_PRODUCT_SPATIAL_COVERAGE` and `INPUT_HLS_PRODUCT_CLOUD_COVERAGE`, respectively;
- Recompute and store the new metadata fields `SPATIAL_COVERAGE` and `CLOUD_COVERAGE` considering fill value and ocean masked data as invalid data;
- Save new metadata fields describing processing parameters used for generating the DSWx-HLS product: `SHADOW_MASKING_ALGORITHM`, `MIN_SLOPE_ANGLE`, `MAX_SUN_LOCAL_INC_ANGLE`, `MASK_ADJACENT_TO_CLOUD_MODE`, `FOREST_MASK_LANDCOVER_CLASSES`, and `OCEAN_MASKING_SHORELINE_DISTANCE_KM`;
- Update version tag from `v.0.5.2` to `v1.0`.
- Add high-aerosol masking.