### PR TITLE
Add support to antimeridian ("dateline") crossing

### DIFF
--- a/bin/dswx_hls.py
+++ b/bin/dswx_hls.py
@@ -86,7 +86,7 @@ def main():
         min_slope_angle = args.min_slope_angle,
         max_sun_local_inc_angle=args.max_sun_local_inc_angle,
         mask_adjacent_to_cloud_mode=args.mask_adjacent_to_cloud_mode,
-        copernicus_forest_classes=args.copernicus_forest_classes,
+        forest_mask_landcover_classes=args.forest_mask_landcover_classes,
         ocean_masking_shoreline_distance_km = \
             args.ocean_masking_shoreline_distance_km,
         flag_debug=args.flag_debug)

--- a/bin/dswx_hls.py
+++ b/bin/dswx_hls.py
@@ -82,6 +82,14 @@ def main():
         product_id=args.product_id,
         product_version=args.product_version,
         check_ancillary_inputs_coverage=args.check_ancillary_inputs_coverage,
+        aerosol_not_water_to_high_conf_water_fmask_values =
+            args.aerosol_not_water_to_high_conf_water_fmask_values,
+        aerosol_water_moderate_conf_to_high_conf_water_fmask_values =
+            args.aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
+        aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values =
+            args.aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
+        aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values =
+            args.aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values,
         shadow_masking_algorithm=args.shadow_masking_algorithm,
         min_slope_angle = args.min_slope_angle,
         max_sun_local_inc_angle=args.max_sun_local_inc_angle,

--- a/bin/dswx_hls.py
+++ b/bin/dswx_hls.py
@@ -82,6 +82,7 @@ def main():
         product_id=args.product_id,
         product_version=args.product_version,
         check_ancillary_inputs_coverage=args.check_ancillary_inputs_coverage,
+        apply_ocean_masking=args.apply_ocean_masking,
         apply_aerosol_class_remapping=args.apply_aerosol_class_remapping,
         aerosol_not_water_to_moderate_conf_water_fmask_values =
             args.aerosol_not_water_to_moderate_conf_water_fmask_values,

--- a/bin/dswx_hls.py
+++ b/bin/dswx_hls.py
@@ -82,15 +82,15 @@ def main():
         product_id=args.product_id,
         product_version=args.product_version,
         check_ancillary_inputs_coverage=args.check_ancillary_inputs_coverage,
-        apply_aerosol_masking=args.apply_aerosol_masking,
-        aerosol_not_water_to_high_conf_water_fmask_values =
-            args.aerosol_not_water_to_high_conf_water_fmask_values,
+        apply_aerosol_class_remapping=args.apply_aerosol_class_remapping,
+        aerosol_not_water_to_moderate_conf_water_fmask_values =
+            args.aerosol_not_water_to_moderate_conf_water_fmask_values,
         aerosol_water_moderate_conf_to_high_conf_water_fmask_values =
             args.aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
-        aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values =
-            args.aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
-        aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values =
-            args.aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values,
+        aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values =
+            args.aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values,
+        aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values =
+            args.aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values,
         shadow_masking_algorithm=args.shadow_masking_algorithm,
         min_slope_angle = args.min_slope_angle,
         max_sun_local_inc_angle=args.max_sun_local_inc_angle,

--- a/bin/dswx_hls.py
+++ b/bin/dswx_hls.py
@@ -82,6 +82,7 @@ def main():
         product_id=args.product_id,
         product_version=args.product_version,
         check_ancillary_inputs_coverage=args.check_ancillary_inputs_coverage,
+        apply_aerosol_masking=args.apply_aerosol_masking,
         aerosol_not_water_to_high_conf_water_fmask_values =
             args.aerosol_not_water_to_high_conf_water_fmask_values,
         aerosol_water_moderate_conf_to_high_conf_water_fmask_values =

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,12 +32,12 @@ RUN set -ex \
 
 # set default user and workdir
 WORKDIR /home/conda
-ADD dist/proteus-0.5.3.tar.gz .
+ADD dist/proteus-1.0.0.tar.gz .
 
 USER root
-RUN mkdir -p proteus-0.5.3/build
+RUN mkdir -p proteus-1.0.0/build
 RUN export PATH=/opt/conda/bin:$PATH
-WORKDIR /home/conda/proteus-0.5.3
+WORKDIR /home/conda/proteus-1.0.0
 RUN python3 setup.py install
 WORKDIR /home/conda
 
@@ -48,7 +48,7 @@ ENV GDAL_DIR /opt/conda
 ENV PATH $GDAL_DIR/bin:$PATH
 ENV GDAL_DATA $GDAL_DIR/share/gdal
 
-ENV PYTHONPATH /home/conda/proteus-0.5.3/src/:$PYTHONPATH
-ENV PATH /home/conda/proteus-0.5.3/bin/:$PATH
+ENV PYTHONPATH /home/conda/proteus-1.0.0/src/:$PYTHONPATH
+ENV PATH /home/conda/proteus-1.0.0/bin/:$PATH
 
 CMD [ "/bin/bash" ]

--- a/src/proteus/defaults/dswx_hls.yaml
+++ b/src/proteus/defaults/dswx_hls.yaml
@@ -78,8 +78,10 @@ runconfig:
             # Define how areas adjacent to cloud/cloud-shadow should be handled
             mask_adjacent_to_cloud_mode: 'mask'
 
-            # Copernicus CGLS Land Cover 100m forest classes
-            copernicus_forest_classes: [20, 111, 113, 115, 116, 121, 123, 125, 126]
+            # Copernicus CGLS Land Cover 100m forest classes to mask out from
+            # the WTR-2 and WTR layer due to dark reflectance that is usually
+            # misinterpreted as water.
+            forest_mask_landcover_classes: [20, 111, 113, 115, 116, 121, 123, 125, 126]
 
             # Ocean masking distance from shoreline in km
             ocean_masking_shoreline_distance_km: 1

--- a/src/proteus/defaults/dswx_hls.yaml
+++ b/src/proteus/defaults/dswx_hls.yaml
@@ -66,6 +66,9 @@ runconfig:
             # Check if ancillary inputs cover entirely the output product
             check_ancillary_inputs_coverage: True
 
+            # Apply ocean masking
+            apply_ocean_masking: True
+
             # Apply aeresol masking
             apply_aerosol_class_remapping: True
 

--- a/src/proteus/defaults/dswx_hls.yaml
+++ b/src/proteus/defaults/dswx_hls.yaml
@@ -66,6 +66,9 @@ runconfig:
             # Check if ancillary inputs cover entirely the output product
             check_ancillary_inputs_coverage: True
 
+            # Apply aeresol masking
+            apply_aerosol_masking: True
+
             # HLS Fmask values to convert not-water to high-confidence water
             # in the presence of high aerosol
             aerosol_not_water_to_high_conf_water_fmask_values: [224, 160, 96]

--- a/src/proteus/defaults/dswx_hls.yaml
+++ b/src/proteus/defaults/dswx_hls.yaml
@@ -67,23 +67,23 @@ runconfig:
             check_ancillary_inputs_coverage: True
 
             # Apply aeresol masking
-            apply_aerosol_masking: True
+            apply_aerosol_class_remapping: True
 
-            # HLS Fmask values to convert not-water to high-confidence water
+            # HLS Fmask values to convert not-water to moderate-confidence water
             # in the presence of high aerosol
-            aerosol_not_water_to_high_conf_water_fmask_values: [224, 160, 96]
+            aerosol_not_water_to_moderate_conf_water_fmask_values: [224, 160, 96]
 
             # HLS Fmask values to convert moderate-confidence water to
             # high-confidence water in the presence of high aerosol
             aerosol_water_moderate_conf_to_high_conf_water_fmask_values: [224, 160, 96]
 
             # HLS Fmask values to convert partial surface water conservative to
-            # high-confidence water in the presence of high aerosol
-            aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values: [224, 160]
+            # moderate-confidence water in the presence of high aerosol
+            aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values: [224, 160]
 
             # HLS Fmask values to convert partial surface water aggressive to
-            # high-confidence water in the presence of high aerosol
-            aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values: [224, 160]
+            # moderateh-confidence water in the presence of high aerosol
+            aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values: [224, 160]
 
             # Select shadow masking algorithm
             shadow_masking_algorithm: sun_local_inc_angle

--- a/src/proteus/defaults/dswx_hls.yaml
+++ b/src/proteus/defaults/dswx_hls.yaml
@@ -66,6 +66,22 @@ runconfig:
             # Check if ancillary inputs cover entirely the output product
             check_ancillary_inputs_coverage: True
 
+            # HLS Fmask values to convert not-water to high-confidence water
+            # in the presence of high aerosol
+            aerosol_not_water_to_high_conf_water_fmask_values: [224, 160, 96]
+
+            # HLS Fmask values to convert moderate-confidence water to
+            # high-confidence water in the presence of high aerosol
+            aerosol_water_moderate_conf_to_high_conf_water_fmask_values: [224, 160, 96]
+
+            # HLS Fmask values to convert partial surface water conservative to
+            # high-confidence water in the presence of high aerosol
+            aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values: [224, 160]
+
+            # HLS Fmask values to convert partial surface water aggressive to
+            # high-confidence water in the presence of high aerosol
+            aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values: [224, 160]
+
             # Select shadow masking algorithm
             shadow_masking_algorithm: sun_local_inc_angle
 

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -4315,7 +4315,7 @@ def generate_dswx_layers(input_list,
 
     # use floor integer to compute spatial and cloud coverage
     spatial_coverage = int(100 * float(n_valid) / total_number_of_pixels)
-    cloud_coverage = int(100 * float(n_cloud_and_valid) / total_number_of_pixels)
+    cloud_coverage = int(100 * float(n_cloud_and_valid) / n_valid)
 
     # print spatial and cloud coverage
     logger.info(f'    spatial coverage [%]:  {spatial_coverage}')

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1713,14 +1713,14 @@ def _compute_preliminary_cloud_layer(fmask, mask_adjacent_to_cloud_mode):
 
        Returns
        -------
-            preliminary_cloud_layer : numpy.ndarray
-                Preliminary cloud mask (without the snow/ice class)
-                with dtype of uint8 and values assigned as follows:
-                0: Not masked
-                1: Cloud shadow or adjacent to cloud/cloud shadow
-                4: Cloud
-                5: Cloud and class 1 (cloud shadow or adjacent to cloud/cloud shadow)
-                255: Fill value (no data)
+       preliminary_cloud_layer : numpy.ndarray
+           Preliminary cloud mask (without the snow/ice class)
+           with dtype of uint8 and values assigned as follows:
+           0: Not masked
+           1: Cloud shadow or adjacent to cloud/cloud shadow
+           4: Cloud
+           5: Cloud and class 1 (cloud shadow or adjacent to cloud/cloud shadow)
+           255: Fill value (no data)
 
        See Also
        ---------

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1496,7 +1496,9 @@ def _get_cloud_layer_ctable():
     mask_ctable.SetColorEntry(7, (127, 127, 255))
 
     # Light ocre - Aerosol reassignment ("0xE4CDA7")
-    mask_ctable.SetColorEntry(8, (228, 205, 167))
+    # mask_ctable.SetColorEntry(8, (228, 205, 167))
+    # Grayish blue - Aerosol reassignment ("0x7393B3")
+    mask_ctable.SetColorEntry(8, (115, 147, 179))
     # Dark gray - Cloud shadow
     mask_ctable.SetColorEntry(9, (64, 64, 64))
     # Cyan - snow/ice

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1154,9 +1154,13 @@ def _apply_aerosol_masking_wtr1_class(wtr_1_layer, fmask, wtr1_class,
             in the presence of high aerosol
     """
 
-    to_mask_array = wtr_1_layer == wtr1_class
+    to_mask_array = None
     for fmask_value in fmask_values:
-        to_mask_array &= fmask == fmask_value
+        if to_mask_array is None:
+            to_mask_array = fmask == fmask_value
+        else:
+            to_mask_array |= fmask == fmask_value
+    to_mask_array &= wtr_1_layer == wtr1_class
     wtr_1_layer[to_mask_array] = WATER_UNCOLLAPSED_HIGH_CONF_CLEAR
 
 

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1195,7 +1195,7 @@ def _apply_aerosol_masking(wtr_1_layer, fmask,
     wtr1_class_fmask_values_dict = {
         WATER_NOT_WATER_CLEAR:
             (aerosol_not_water_to_high_conf_water_fmask_values,
-             WATER_UNCOLLAPSED_HIGH_CONF_CLEAR),
+             WATER_UNCOLLAPSED_MODERATE_CONF_CLEAR),
         WATER_UNCOLLAPSED_MODERATE_CONF_CLEAR:
             (aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
              WATER_UNCOLLAPSED_HIGH_CONF_CLEAR),

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -3719,7 +3719,8 @@ def _compute_hillshade(dem_file, scratch_dir, sun_azimuth_angle,
 def _compute_opera_shadow_layer(dem, sun_azimuth_angle, sun_elevation_angle,
                                 min_slope_angle, max_sun_local_inc_angle,
                                 pixel_spacing_x = 30, pixel_spacing_y = 30):
-    """Compute hillshade using new OPERA shadow masking
+    """Compute shadow mask based on Sun local incidence angle and slope
+       angle.
 
        Parameters
        ----------
@@ -3742,8 +3743,8 @@ def _compute_opera_shadow_layer(dem, sun_azimuth_angle, sun_elevation_angle,
 
        Returns
        -------
-       hillshade : numpy.ndarray
-              Hillshade
+       shadow_mask : numpy.ndarray
+              Shadow mask (1: not shadow, 0: shadow)
     """
     sun_azimuth = np.radians(sun_azimuth_angle)
     sun_zenith_degrees = 90 - sun_elevation_angle

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -315,20 +315,20 @@ class RunConfigConstants:
         HLS reflectance thresholds for generating DSWx-HLS products
     check_ancillary_inputs_coverage: bool
         Check if ancillary inputs cover entirely the output product
-    apply_aerosol_masking: bool
+    apply_aerosol_class_remapping: bool
         Apply aerosol masking
-    aerosol_not_water_to_high_conf_water_fmask_values: list(int)
-         HLS Fmask values to convert not-water to high-confidence water
+    aerosol_not_water_to_moderate_conf_water_fmask_values: list(int)
+         HLS Fmask values to convert not-water to moderate-confidence water
          in the presence of high aerosol
     aerosol_water_moderate_conf_to_high_conf_water_fmask_values: list(int)
          HLS Fmask values to convert moderate-confidence water to
          high-confidence water in the presence of high aerosol
-    aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values: list(int)
+    aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values: list(int)
          HLS Fmask values to convert partial surface water conservative to
-         high-confidence water in the presence of high aerosol
-    aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values: list(int)
+         moderate-confidence water in the presence of high aerosol
+    aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values: list(int)
          HLS Fmask values to convert partial surface water aggressive to
-         high-confidence water in the presence of high aerosol
+         moderate-confidence water in the presence of high aerosol
     shadow_masking_algorithm: str
         Shadow masking algorithm
     min_slope_angle: float
@@ -373,11 +373,11 @@ class RunConfigConstants:
     def __init__(self):
         self.hls_thresholds = HlsThresholds()
         self.check_ancillary_inputs_coverage = None
-        self.apply_aerosol_masking = None
-        self.aerosol_not_water_to_high_conf_water_fmask_values = None
+        self.apply_aerosol_class_remapping = None
+        self.aerosol_not_water_to_moderate_conf_water_fmask_values = None
         self.aerosol_water_moderate_conf_to_high_conf_water_fmask_values = None
-        self.aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values = None
-        self.aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values = None
+        self.aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values = None
+        self.aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values = None
         self.shadow_masking_algorithm = None
         self.min_slope_angle = None
         self.max_sun_local_inc_angle = None
@@ -618,7 +618,7 @@ def get_dswx_hls_cli_parser():
                               ' the output product'))
 
     parser.add_argument('--apply-aerosol-masking',
-                        dest='apply_aerosol_masking',
+                        dest='apply_aerosol_class_remapping',
                         action='store_true',
                         default=None,
                         help='Apply aerosol masking')
@@ -1135,7 +1135,7 @@ def _is_landcover_class_high_intensity_developed(landcover_mask):
     return high_intensity_developed_mask
 
 
-def _apply_aerosol_masking_wtr1_class(wtr_1_layer, fmask,
+def _apply_aerosol_class_remapping_wtr1_class(wtr_1_layer, fmask,
         fmask_values, input_wtr1_class, output_wtr1_class):
     """Apply aerosol masking onto interpreted layer (WTR-1) given a
        WTR-1 class and fmask values
@@ -1147,12 +1147,12 @@ def _apply_aerosol_masking_wtr1_class(wtr_1_layer, fmask,
        fmask: numpy.ndarray
             HLS Fmask
        fmask_values: list(int)
-            HLS Fmask values to convert not-water to high-confidence water
+            HLS Fmask values to remap interpreted water classes
             in the presence of high aerosol
        input_wtr1_class: int
             Input WTR-1 class that is being evaluated for high-aerosol
        output_wtr1_class: int
-            Output WTR-1 class if input WTR-1 class has high-aerosol
+            Remapped WTR-1 class
     """
 
     to_mask_array = None
@@ -1165,11 +1165,11 @@ def _apply_aerosol_masking_wtr1_class(wtr_1_layer, fmask,
     wtr_1_layer[to_mask_array] = output_wtr1_class
 
 
-def _apply_aerosol_masking(wtr_1_layer, fmask,
-        aerosol_not_water_to_high_conf_water_fmask_values,
+def _apply_aerosol_class_remapping(wtr_1_layer, fmask,
+        aerosol_not_water_to_moderate_conf_water_fmask_values,
         aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
-        aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
-        aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values):
+        aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values,
+        aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values):
     """Apply aerosol masking onto interpreted layer (WTR-1)
 
        Parameters
@@ -1178,38 +1178,39 @@ def _apply_aerosol_masking(wtr_1_layer, fmask,
             Interpreted layer (WTR-1) (mutable numpy.ndarray)
        fmask: numpy.ndarray
             HLS Fmask
-       aerosol_not_water_to_high_conf_water_fmask_values: list(int)
-           HLS Fmask values to convert not-water to high-confidence water
+       aerosol_not_water_to_moderate_conf_water_fmask_values: list(int)
+           HLS Fmask values to convert not-water to moderate-confidence water
            in the presence of high aerosol
        aerosol_water_moderate_conf_to_high_conf_water_fmask_values: list(int)
            HLS Fmask values to convert moderate-confidence water to
            high-confidence water in the presence of high aerosol
-       aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values: list(int)
+       aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values: list(int)
            HLS Fmask values to convert partial surface water conservative to
-           high-confidence water in the presence of high aerosol
-       aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values: list(int)
+           moderate-confidence water in the presence of high aerosol
+       aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values: list(int)
            HLS Fmask values to convert partial surface water aggressive to
-           high-confidence water in the presence of high aerosol
+           moderate-confidence water in the presence of high aerosol
     """
 
+    # add a not here that nothing changes for high-conf. water
     wtr1_class_fmask_values_dict = {
         WATER_NOT_WATER_CLEAR:
-            (aerosol_not_water_to_high_conf_water_fmask_values,
+            (aerosol_not_water_to_moderate_conf_water_fmask_values,
              WATER_UNCOLLAPSED_MODERATE_CONF_CLEAR),
         WATER_UNCOLLAPSED_MODERATE_CONF_CLEAR:
             (aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
              WATER_UNCOLLAPSED_HIGH_CONF_CLEAR),
         WATER_UNCOLLAPSED_PARTIAL_SURFACE_WATER_CONSERVATIVE_CLEAR:
-            (aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
+            (aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values,
              WATER_UNCOLLAPSED_MODERATE_CONF_CLEAR),
         WATER_UNCOLLAPSED_PARTIAL_SURFACE_WATER_AGGRESSIVE_CLEAR:
-            (aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values,
+            (aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values,
              WATER_UNCOLLAPSED_MODERATE_CONF_CLEAR)
         }
 
     for input_wtr1_class, (fmask_values, output_wtr1_class) in \
             wtr1_class_fmask_values_dict.items():
-        _apply_aerosol_masking_wtr1_class(wtr_1_layer, fmask,
+        _apply_aerosol_class_remapping_wtr1_class(wtr_1_layer, fmask,
             fmask_values, input_wtr1_class, output_wtr1_class)
 
 
@@ -1459,6 +1460,8 @@ def _get_cloud_layer_ctable():
     # - Mask cloud shadow bit (0)
     # - Mask snow/ice bit (1)
     # - Mask cloud bit (2)
+    # - Class re-assignment due to aerosol interpolation errors (3)
+    # rusty ocre / gray green / grayish yellow
 
     # White - Not masked
     mask_ctable.SetColorEntry(0, (255, 255, 255))
@@ -1478,6 +1481,7 @@ def _get_cloud_layer_ctable():
     mask_ctable.SetColorEntry(7, (127, 127, 255))
     # Dark blue - Ocean masked
     mask_ctable.SetColorEntry(CLOUD_OCEAN_MASKED, OCEAN_MASKED_RGBA)
+
     # Black - Fill value
     mask_ctable.SetColorEntry(UINT8_FILL_VALUE, FILL_VALUE_RGBA)
     return mask_ctable
@@ -3658,10 +3662,10 @@ def _populate_dswx_metadata_datasets(dswx_metadata_dict,
 
 def _populate_dswx_metadata_processing_parameters(
         dswx_metadata_dict,
-        aerosol_not_water_to_high_conf_water_fmask_values,
+        aerosol_not_water_to_moderate_conf_water_fmask_values,
         aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
-        aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
-        aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values,
+        aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values,
+        aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values,
         shadow_masking_algorithm,
         min_slope_angle,
         max_sun_local_inc_angle,
@@ -3675,18 +3679,18 @@ def _populate_dswx_metadata_processing_parameters(
        ----------
        dswx_metadata_dict : collections.OrderedDict
               Metadata dictionary
-       aerosol_not_water_to_high_conf_water_fmask_values: list(int)
-              HLS Fmask values to convert not-water to high-confidence water
+       aerosol_not_water_to_moderate_conf_water_fmask_values: list(int)
+              HLS Fmask values to convert not-water to moderate-confidence water
               in the presence of high aerosol
        aerosol_water_moderate_conf_to_high_conf_water_fmask_values: list(int)
               HLS Fmask values to convert moderate-confidence water to
               high-confidence water in the presence of high aerosol
-       aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values: list(int)
+       aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values: list(int)
               HLS Fmask values to convert partial surface water conservative to
-              high-confidence water in the presence of high aerosol
-       aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values: list(int)
+              moderate-confidence water in the presence of high aerosol
+       aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values: list(int)
               HLS Fmask values to convert partial surface water aggressive to
-              high-confidence water in the presence of high aerosol
+              moderate-confidence water in the presence of high aerosol
        shadow_masking_algorithm: str
               Shadow masking algorithm
        min_slope_angle: float
@@ -3707,14 +3711,14 @@ def _populate_dswx_metadata_processing_parameters(
 
     # aerosol metadata fields
     aerosol_metadata_dict = {
-        'aerosol_not_water_to_high_conf_water_fmask_values':
-            aerosol_not_water_to_high_conf_water_fmask_values,
+        'aerosol_not_water_to_moderate_conf_water_fmask_values':
+            aerosol_not_water_to_moderate_conf_water_fmask_values,
         'aerosol_water_moderate_conf_to_high_conf_water_fmask_values':
             aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
-        'aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values':
-            aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
-        'aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values':
-            aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values,
+        'aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values':
+            aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values,
+        'aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values':
+            aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values,
     }
 
     for aerosol_metadata_field_lower, fmask_values in aerosol_metadata_dict.items():
@@ -4154,11 +4158,11 @@ def generate_dswx_layers(input_list,
                          product_id=None,
                          product_version=SOFTWARE_VERSION,
                          check_ancillary_inputs_coverage=None,
-                         apply_aerosol_masking=None,
-                         aerosol_not_water_to_high_conf_water_fmask_values=None,
+                         apply_aerosol_class_remapping=None,
+                         aerosol_not_water_to_moderate_conf_water_fmask_values=None,
                          aerosol_water_moderate_conf_to_high_conf_water_fmask_values=None,
-                         aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values=None,
-                         aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values=None,
+                         aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values=None,
+                         aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values=None,
                          shadow_masking_algorithm=None,
                          min_slope_angle=None,
                          max_sun_local_inc_angle=None,
@@ -4246,20 +4250,20 @@ def generate_dswx_layers(input_list,
               metadata
        check_ancillary_inputs_coverage: bool (optional)
               Check if ancillary inputs cover entirely the output product
-       apply_aerosol_masking: bool (optional)
+       apply_aerosol_class_remapping: bool (optional)
               Apply aerosol masking
-       aerosol_not_water_to_high_conf_water_fmask_values: list(int) (optional)
-              HLS Fmask values to convert not-water to high-confidence water
+       aerosol_not_water_to_moderate_conf_water_fmask_values: list(int) (optional)
+              HLS Fmask values to convert not-water to moderate-confidence water
               in the presence of high aerosol
        aerosol_water_moderate_conf_to_high_conf_water_fmask_values: list(int) (optional)
               HLS Fmask values to convert moderate-confidence water to
               high-confidence water in the presence of high aerosol
-       aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values: list(int) (optional)
+       aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values: list(int) (optional)
               HLS Fmask values to convert partial surface water conservative to
-              high-confidence water in the presence of high aerosol
-       aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values: list(int) (optional)
+              moderate-confidence water in the presence of high aerosol
+       aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values: list(int) (optional)
               HLS Fmask values to convert partial surface water aggressive to
-              high-confidence water in the presence of high aerosol
+              moderate-confidence water in the presence of high aerosol
        shadow_masking_algorithm: str (optional)
               Shadow masking algorithm. Choices: "otsu" or "sun_local_inc_angle"
        min_slope_angle: float (optional)
@@ -4285,11 +4289,11 @@ def generate_dswx_layers(input_list,
     flag_read_runconfig_constants = \
         any([p is None for p in [hls_thresholds,
                                  check_ancillary_inputs_coverage,
-                                 apply_aerosol_masking,
-                                 aerosol_not_water_to_high_conf_water_fmask_values,
+                                 apply_aerosol_class_remapping,
+                                 aerosol_not_water_to_moderate_conf_water_fmask_values,
                                  aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
-                                 aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
-                                 aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values,
+                                 aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values,
+                                 aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values,
                                  shadow_masking_algorithm,
                                  min_slope_angle,
                                  max_sun_local_inc_angle,
@@ -4310,20 +4314,20 @@ def generate_dswx_layers(input_list,
         if check_ancillary_inputs_coverage is None:
             check_ancillary_inputs_coverage = \
                 runconfig_constants.check_ancillary_inputs_coverage
-        if apply_aerosol_masking is None:
-            apply_aerosol_masking = runconfig.constants.apply_aerosol_masking
-        if aerosol_not_water_to_high_conf_water_fmask_values is None:
-            aerosol_not_water_to_high_conf_water_fmask_values = \
-                runconfig_constants.aerosol_not_water_to_high_conf_water_fmask_values
+        if apply_aerosol_class_remapping is None:
+            apply_aerosol_class_remapping = runconfig.constants.apply_aerosol_class_remapping
+        if aerosol_not_water_to_moderate_conf_water_fmask_values is None:
+            aerosol_not_water_to_moderate_conf_water_fmask_values = \
+                runconfig_constants.aerosol_not_water_to_moderate_conf_water_fmask_values
         if aerosol_water_moderate_conf_to_high_conf_water_fmask_values is None:
             aerosol_water_moderate_conf_to_high_conf_water_fmask_values = \
                 runconfig_constants.aerosol_water_moderate_conf_to_high_conf_water_fmask_values
-        if aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values is None:
-            aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values = \
-                runconfig_constants.aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values
-        if aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values is None:
-            aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values = \
-                runconfig_constants.aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values
+        if aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values is None:
+            aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values = \
+                runconfig_constants.aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values
+        if aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values is None:
+            aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values = \
+                runconfig_constants.aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values
         if shadow_masking_algorithm is None:
             shadow_masking_algorithm = \
                 runconfig_constants.shadow_masking_algorithm
@@ -4390,30 +4394,30 @@ def generate_dswx_layers(input_list,
                 f' {check_ancillary_inputs_coverage}')
                 
     logger.info(f'    apply aerosol masking:'
-                f' {apply_aerosol_masking}')
-    if apply_aerosol_masking:
-        aerosol_masking_unused_parameters_str = ''
+                f' {apply_aerosol_class_remapping}')
+    if apply_aerosol_class_remapping:
+        aerosol_class_remapping_unused_parameters_str = ''
     else:
-        aerosol_masking_unused_parameters_str = ' (unused)'
+        aerosol_class_remapping_unused_parameters_str = ' (unused)'
     logger.info(
-        f'        not-water to high-confidence water Fmask values:' +
-        f' {aerosol_not_water_to_high_conf_water_fmask_values}' +
-        aerosol_masking_unused_parameters_str)
+        f'        not-water to moderate-confidence water Fmask values:' +
+        f' {aerosol_not_water_to_moderate_conf_water_fmask_values}' +
+        aerosol_class_remapping_unused_parameters_str)
     logger.info(
         f'        moderate confidence water to'
         f' high-confidence water Fmask values:' +
         f' {aerosol_water_moderate_conf_to_high_conf_water_fmask_values}' +
-        aerosol_masking_unused_parameters_str)
+        aerosol_class_remapping_unused_parameters_str)
     logger.info(
         f'        partial surface water conservative to'
-        f' high-confidence water Fmask values:' +
-        f' {aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values}' +
-        aerosol_masking_unused_parameters_str)
+        f' moderate-confidence water Fmask values:' +
+        f' {aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values}' +
+        aerosol_class_remapping_unused_parameters_str)
     logger.info(
         f'        partial surface water aggressive to'
-        f' high-confidence water Fmask values:' +
-        f' {aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values}' +
-        aerosol_masking_unused_parameters_str)
+        f' moderate-confidence water Fmask values:' +
+        f' {aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values}' +
+        aerosol_class_remapping_unused_parameters_str)
     logger.info(f'    shadow masking algorithm: {shadow_masking_algorithm}')
     if shadow_masking_algorithm == 'otsu':
         terrain_masking_parameters_str = ' (unused)'
@@ -4497,14 +4501,14 @@ def generate_dswx_layers(input_list,
 
     _populate_dswx_metadata_processing_parameters(
         dswx_metadata_dict,
-        aerosol_not_water_to_high_conf_water_fmask_values =
-            aerosol_not_water_to_high_conf_water_fmask_values,
+        aerosol_not_water_to_moderate_conf_water_fmask_values =
+            aerosol_not_water_to_moderate_conf_water_fmask_values,
         aerosol_water_moderate_conf_to_high_conf_water_fmask_values =
             aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
-        aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values =
-            aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
-        aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values =
-            aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values,
+        aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values =
+            aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values,
+        aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values =
+            aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values,
         shadow_masking_algorithm=shadow_masking_algorithm,
         min_slope_angle=min_slope_angle,
         max_sun_local_inc_angle=max_sun_local_inc_angle,
@@ -4618,7 +4622,7 @@ def generate_dswx_layers(input_list,
 
     # update DSWx-HLS metadata dictionary
     dswx_metadata_dict['SPATIAL_COVERAGE'] = spatial_coverage
-    dswx_metadata_dict['SPATIAL_COVERAGE_AFTER_OCEAN_MASKING'] = \
+    dswx_metadata_dict['SPATIAL_COVERAGE_EXCLUDING_MASKED_OCEAN'] = \
         spatial_coverage_after_ocean_masking
     dswx_metadata_dict['CLOUD_COVERAGE'] = cloud_coverage
 
@@ -4744,12 +4748,12 @@ def generate_dswx_layers(input_list,
                           scratch_dir=scratch_dir,
                           output_files_list=build_vrt_list)
 
-    if apply_aerosol_masking:
-        _apply_aerosol_masking(wtr_1_layer, fmask,
-            aerosol_not_water_to_high_conf_water_fmask_values,
+    if apply_aerosol_class_remapping:
+        _apply_aerosol_class_remapping(wtr_1_layer, fmask,
+            aerosol_not_water_to_moderate_conf_water_fmask_values,
             aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
-            aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
-            aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values)
+            aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values,
+            aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values)
 
     wtr_2_layer = _apply_landcover_and_shadow_masks(
         wtr_1_layer, nir, landcover_mask, shadow_layer,

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -4544,7 +4544,6 @@ def generate_dswx_layers(input_list,
     cloud = _add_snow_to_cloud_layer(
         wtr_2_layer, preliminary_cloud_layer, fmask,
         mask_adjacent_to_cloud_mode)
-    del preliminary_cloud_layer
 
     wtr_layer = _apply_cloud_masking(wtr_2_layer, cloud)
 

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -3500,6 +3500,7 @@ def _populate_dswx_metadata_processing_parameters(
         max_sun_local_inc_angle,
         mask_adjacent_to_cloud_mode,
         forest_mask_landcover_classes,
+        shoreline_shapefile,
         ocean_masking_shoreline_distance_km):
     """Populate metadata dictionary with processing parameters
 
@@ -3519,6 +3520,8 @@ def _populate_dswx_metadata_processing_parameters(
               Copernicus CGLS Land Cover 100m forest classes to mask out from
               the WTR-2 and WTR layer due to dark reflectance that is usually
               misinterpreted as water.
+       shoreline_shapefile:
+              NOAA shoreline shapefile
        ocean_masking_shoreline_distance_km: float
               Ocean masking distance from shoreline in km
     """
@@ -3541,8 +3544,11 @@ def _populate_dswx_metadata_processing_parameters(
         ','.join([str(c) for c in forest_mask_landcover_classes])
 
     # ocean masking distance from shoreline in km
-    dswx_metadata_dict['OCEAN_MASKING_SHORELINE_DISTANCE_KM'] = \
-        ocean_masking_shoreline_distance_km
+    if shoreline_shapefile:
+        dswx_metadata_dict['OCEAN_MASKING_SHORELINE_DISTANCE_KM'] = \
+            ocean_masking_shoreline_distance_km
+    else:
+        dswx_metadata_dict['OCEAN_MASKING_SHORELINE_DISTANCE_KM'] = '-'
 
 
 class Logger(object):
@@ -4231,6 +4237,7 @@ def generate_dswx_layers(input_list,
         max_sun_local_inc_angle=max_sun_local_inc_angle,
         mask_adjacent_to_cloud_mode=mask_adjacent_to_cloud_mode,
         forest_mask_landcover_classes=forest_mask_landcover_classes,
+        shoreline_shapefile = shoreline_shapefile,
         ocean_masking_shoreline_distance_km =
             ocean_masking_shoreline_distance_km)
 

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1346,7 +1346,7 @@ def _get_interpreted_dswx_ctable(
                                   (0, 0, 255)) 
         # Light blue - Water (moderate conf.)
         dswx_ctable.SetColorEntry(WATER_UNCOLLAPSED_MODERATE_CONF_CLEAR,
-                                  (173, 173, 252))
+                                  (0, 127, 255))
         # Dark green - Partial surface water conservative
         dswx_ctable.SetColorEntry(
             WATER_UNCOLLAPSED_PARTIAL_SURFACE_WATER_CONSERVATIVE_CLEAR, 

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -947,8 +947,9 @@ def create_landcover_mask(copernicus_landcover_file,
         dir=scratch_dir, suffix='.tif').name
 
     copernicus_landcover_array = _warp(copernicus_landcover_file,
-        geotransform, projection,
-        length, width, scratch_dir, resample_algorithm='nearest',
+        geotransform, projection, length, width,
+        flag_crosses_antimeridian,
+        scratch_dir, resample_algorithm='nearest',
         relocated_file=copernicus_landcover_reprojected_file,
         temp_files_list=temp_files_list)
     temp_files_list.append(copernicus_landcover_reprojected_file)
@@ -962,8 +963,8 @@ def create_landcover_mask(copernicus_landcover_file,
     worldcover_reprojected_up_3_file = tempfile.NamedTemporaryFile(
         dir=scratch_dir, suffix='.tif').name
     worldcover_array_up_3 = _warp(worldcover_file, geotransform_up_3,
-        projection, length_up_3, width_up_3, scratch_dir,
-        resample_algorithm='nearest',
+        projection, length_up_3, width_up_3, flag_crosses_antimeridian,
+        scratch_dir, resample_algorithm='nearest',
         relocated_file=worldcover_reprojected_up_3_file,
         temp_files_list=temp_files_list)
     temp_files_list.append(worldcover_reprojected_up_3_file)
@@ -3082,10 +3083,11 @@ def get_projection_proj4(projection):
 
 
 def _warp(input_file, geotransform, projection,
-              length, width, scratch_dir = '.',
-              resample_algorithm='nearest',
-              relocated_file=None, margin_in_pixels=0,
-              temp_files_list = None):
+          length, width, flag_crosses_antimeridian,
+          scratch_dir = '.',
+          resample_algorithm='nearest',
+          relocated_file=None, margin_in_pixels=0,
+          temp_files_list = None):
     """Relocate/reproject a file (e.g., landcover or DEM) based on geolocation
        defined by a geotransform, output dimensions (length and width)
        and projection
@@ -3104,6 +3106,9 @@ def _warp(input_file, geotransform, projection,
        width: int
               Output width before adding the margin defined by
               `margin_in_pixels`
+       flag_crosses_antimeridian: bool
+              Flag that indicates if the HLS product crosses
+              the anti-meridian ("dateline")
        scratch_dir: str (optional)
               Directory for temporary files
        resample_algorithm: str
@@ -3128,16 +3133,16 @@ def _warp(input_file, geotransform, projection,
     dx = geotransform[1]
 
     # Output Y-coordinate start (North) position with margin
-    y0 = geotransform[3] - margin_in_pixels * dy
+    y_max = geotransform[3] - margin_in_pixels * dy
 
     # Output X-coordinate start (West) position with margin
-    x0 = geotransform[0] - margin_in_pixels * dx
+    x_min = geotransform[0] - margin_in_pixels * dx
 
     # Output Y-coordinate end (South) position with margin
-    yf = y0 + (length + 2 * margin_in_pixels) * dy
+    y_min = y_max + (length + 2 * margin_in_pixels) * dy
 
     # Output X-coordinate end (East) position with margin
-    xf = x0 + (width + 2 * margin_in_pixels) * dx
+    x_max = x_min + (width + 2 * margin_in_pixels) * dx
 
     # Set output spatial reference system (SRS) from projection
     dstSRS = get_projection_proj4(projection)
@@ -3155,11 +3160,90 @@ def _warp(input_file, geotransform, projection,
 
     _makedirs(relocated_file)
 
-    gdal.Warp(relocated_file, input_file, format='GTiff',
-              dstSRS=dstSRS,
-              outputBounds=[x0, yf, xf, y0], multithread=True,
-              xRes=dx, yRes=abs(dy), resampleAlg=resample_algorithm,
-              errorThreshold=0)
+    if not flag_crosses_antimeridian:
+        gdal.Warp(relocated_file, input_file, format='GTiff',
+                dstSRS=dstSRS,
+                outputBounds=[x_min, y_min, x_max, y_max], multithread=True,
+                xRes=dx, yRes=abs(dy), resampleAlg=resample_algorithm,
+                errorThreshold=0)
+        gdal_ds = gdal.Open(relocated_file, gdal.GA_ReadOnly)
+        relocated_array = gdal_ds.ReadAsArray()
+        del gdal_ds
+
+        return relocated_array
+
+    # get input's bounding box (bbox) and its bbox polygon
+    gdal_ds = gdal.Open(input_file, gdal.GA_ReadOnly)
+
+    file_geotransform = gdal_ds.GetGeoTransform()
+    file_projection = gdal_ds.GetProjection()
+    min_x, dx, _, max_y, _, dy = file_geotransform
+
+    file_width = gdal_ds.GetRasterBand(1).XSize
+    file_length = gdal_ds.GetRasterBand(1).YSize
+
+    del gdal_ds
+
+    max_x = min_x + file_width * dx
+    min_y = max_y + file_length * dy
+
+    file_srs = osr.SpatialReference()
+    file_srs.ImportFromProj4(file_projection)
+    tile_polygon, tile_min_y, tile_max_y, tile_min_x, tile_max_x = \
+        _get_tile_srs_bbox(tile_min_y_utm, tile_max_y_utm,
+                           tile_min_x_utm, tile_max_x_utm,
+                           tile_srs, file_srs)
+
+    # Create input ancillary polygon
+    file_polygon = _get_ogr_polygon(min_x, max_y, max_x, min_y, file_srs)
+
+
+
+    logger.info(f'The input HLS product crosses the anti-meridian'
+                ' (dateline). Verifying the'
+                f' {file_description}: {file_name}')
+
+    # Left side of the anti-meridian crossing: -180 -> +180
+    file_polygon_1 = _get_ogr_polygon(-180, 90, max_x, -90, file_srs)
+    intersection_1 = tile_polygon.Intersection(file_polygon_1)
+    flag_1_ok = intersection_1.Within(file_polygon)
+    check_1_str = 'ok' if flag_1_ok else 'fail'
+    logger.info(f'    left side (-180 -> +180): {check_1_str}')
+
+    # Right side of the anti-meridian crossing: +180 -> +360
+    buffer_in_degrees = 0.0002777  # buffer of 1 arcsec: ~ 30m
+    file_polygon_2 = _get_ogr_polygon(
+        max_x + buffer_in_degrees, 90, max_x + 360, -90, file_srs)
+    intersection_2 = tile_polygon.Intersection(file_polygon_2)
+    file_polygon_2 = _get_ogr_polygon(min_x + 360, max_y,
+                                            max_x + 360, min_y,
+                                            file_srs)
+    flag_2_ok = intersection_2.Within(file_polygon_2)
+    check_2_str = 'ok' if flag_2_ok else 'fail'
+    logger.info(f'    right side (+180 -> +360): {check_2_str}')
+
+
+    # temporary files
+    cropped_input_antimeridian_left_temp = tempfile.NamedTemporaryFile(
+                dir=scratch_dir, suffix='.tif').name
+    logger.info(f'    relocating file: {input_file} to'
+                f' temporary file: {cropped_input_antimeridian_left_temp}')
+    if temp_files_list is not None:
+        temp_files_list.append(cropped_input_antimeridian_left_temp)
+    cropped_input_antimeridian_right_temp = tempfile.NamedTemporaryFile(
+                dir=scratch_dir, suffix='.tif').name
+    logger.info(f'    relocating file: {input_file} to'
+                f' temporary file: {cropped_input_antimeridian_right_temp}')
+    if temp_files_list is not None:
+        temp_files_list.append(cropped_input_antimeridian_right_temp)
+
+    gdal.Translate(cropped_input_antimeridian_left_temp, input_file)
+    gdal.Translate(cropped_input_antimeridian_right_temp, input_file)
+
+
+
+
+
 
     gdal_ds = gdal.Open(relocated_file, gdal.GA_ReadOnly)
     relocated_array = gdal_ds.ReadAsArray()
@@ -4161,26 +4245,61 @@ def _check_ancillary_inputs(check_ancillary_inputs_coverage,
                                tile_srs, file_srs)
 
         # Create input ancillary polygon
-        file_ring = ogr.Geometry(ogr.wkbLinearRing)
-        file_ring.AddPoint(min_x, max_y)
-        file_ring.AddPoint(max_x, max_y)
-        file_ring.AddPoint(max_x, min_y)
-        file_ring.AddPoint(min_x, min_y)
-        file_ring.AddPoint(min_x, max_y)
-        file_polygon = ogr.Geometry(ogr.wkbPolygon)
-        file_polygon.AddGeometry(file_ring)
-        file_polygon.AssignSpatialReference(file_srs)
-        assert file_polygon.IsValid()
+        file_polygon = _get_ogr_polygon(min_x, max_y, max_x, min_y, file_srs)
 
-        if not tile_polygon.Within(file_polygon):
-            error_msg = f'ERROR the {file_description} with extents'
-            error_msg += f' S/N: [{min_y},{max_y}]'
-            error_msg += f' W/E: [{min_x},{max_x}],'
-            error_msg += ' does not fully cover input tile with'
-            error_msg += f' extents S/N: [{tile_min_y},{tile_max_y}]'
-            error_msg += f' W/E: [{tile_min_x},{tile_max_x}]'
-            logger.error(error_msg)
-            raise ValueError(error_msg)
+        if tile_polygon.Within(file_polygon):
+            continue
+
+        # Handle anti-meridian ("dateline") crossing
+        if file_srs.IsGeographic() and tile_min_x < 180 and tile_max_x >= 180:
+
+            logger.info(f'The input HLS product crosses the anti-meridian'
+                        ' (dateline). Verifying the'
+                        f' {file_description}: {file_name}')
+
+            # Left side of the anti-meridian crossing: -180 -> +180
+            file_polygon_1 = _get_ogr_polygon(-180, 90, max_x, -90, file_srs)
+            intersection_1 = tile_polygon.Intersection(file_polygon_1)
+            flag_1_ok = intersection_1.Within(file_polygon)
+            check_1_str = 'ok' if flag_1_ok else 'fail'
+            logger.info(f'    left side (-180 -> +180): {check_1_str}')
+
+            # Right side of the anti-meridian crossing: +180 -> +360
+            buffer_in_degrees = 0.0002777  # buffer of 1 arcsec: ~ 30m
+            file_polygon_2 = _get_ogr_polygon(
+                max_x + buffer_in_degrees, 90, max_x + 360, -90, file_srs)
+            intersection_2 = tile_polygon.Intersection(file_polygon_2)
+            file_polygon_2 = _get_ogr_polygon(min_x + 360, max_y,
+                                                    max_x + 360, min_y,
+                                                    file_srs)
+            flag_2_ok = intersection_2.Within(file_polygon_2)
+            check_2_str = 'ok' if flag_2_ok else 'fail'
+            logger.info(f'    right side (+180 -> +360): {check_2_str}')
+
+            if flag_1_ok and flag_2_ok:
+                continue
+
+        error_msg = f'ERROR the {file_description} with extents'
+        error_msg += f' S/N: [{min_y},{max_y}]'
+        error_msg += f' W/E: [{min_x},{max_x}],'
+        error_msg += ' does not fully cover input tile with'
+        error_msg += f' extents S/N: [{tile_min_y},{tile_max_y}]'
+        error_msg += f' W/E: [{tile_min_x},{tile_max_x}]'
+        logger.error(error_msg)
+        raise ValueError(error_msg)
+
+def _get_ogr_polygon(min_x, max_y, max_x, min_y, file_srs):
+    file_ring = ogr.Geometry(ogr.wkbLinearRing)
+    file_ring.AddPoint(min_x, max_y)
+    file_ring.AddPoint(max_x, max_y)
+    file_ring.AddPoint(max_x, min_y)
+    file_ring.AddPoint(min_x, min_y)
+    file_ring.AddPoint(min_x, max_y)
+    file_polygon = ogr.Geometry(ogr.wkbPolygon)
+    file_polygon.AddGeometry(file_ring)
+    file_polygon.AssignSpatialReference(file_srs)
+    assert file_polygon.IsValid()
+    return file_polygon
 
 
 def generate_dswx_layers(input_list,
@@ -4715,8 +4834,8 @@ def generate_dswx_layers(input_list,
             temp_files_list.append(dem_cropped_file)
         logger.info(f'Preparing DEM file: {dem_file}')
         dem_with_margin = _warp(dem_file, geotransform, projection,
-                                    length, width, scratch_dir,
-                                    resample_algorithm='cubic',
+                                    length, width, flag_crosses_antimeridian,
+                                    scratch_dir, resample_algorithm='cubic',
                                     relocated_file=dem_cropped_file,
                                     margin_in_pixels=DEM_MARGIN_IN_PIXELS,
                                     temp_files_list=temp_files_list)

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -4355,14 +4355,31 @@ def generate_dswx_layers(input_list,
 
     # use floor integer to compute spatial and cloud coverage
     spatial_coverage = int(100 * float(n_valid) / total_number_of_pixels)
-    cloud_coverage = int(100 * float(n_cloud_and_valid) / n_valid)
+    if n_valid == 0:
+        cloud_coverage = 0
+    else:
+        cloud_coverage = int(100 * float(n_cloud_and_valid) / n_valid)
+
+    if ocean_mask is not None:
+        n_not_ocean = np.sum(ocean_mask) 
+    else:
+        n_not_ocean = total_number_of_pixels
+
+    if n_not_ocean == 0:
+        spatial_coverage_after_ocean_masking = 0
+    else:
+        spatial_coverage_after_ocean_masking = int(100 * float(n_valid) / n_not_ocean)
 
     # print spatial and cloud coverage
     logger.info(f'    spatial coverage [%]:  {spatial_coverage}')
+    logger.info(f'    spatial coverage after ocean masking [%]:'
+                f' {spatial_coverage_after_ocean_masking}')
     logger.info(f'    cloud coverage [%]:  {cloud_coverage}')
 
     # update DSWx-HLS metadata dictionary
     dswx_metadata_dict['SPATIAL_COVERAGE'] = spatial_coverage
+    dswx_metadata_dict['SPATIAL_COVERAGE_AFTER_OCEAN_MASKING'] = \
+        spatial_coverage_after_ocean_masking
     dswx_metadata_dict['CLOUD_COVERAGE'] = cloud_coverage
 
     if dem_file is not None:

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1345,24 +1345,24 @@ def _get_interpreted_dswx_ctable(
     if flag_collapse_wtr_classes:
         # Blue - Open water
         dswx_ctable.SetColorEntry(WATER_COLLAPSED_OPEN_WATER,
-                                  (0, 0, 255)) 
-        # Light Blue - Partial surface water
+                                  (0, 0, 255))
+        # Light blue - Partial surface water
         dswx_ctable.SetColorEntry(WATER_COLLAPSED_PARTIAL_SURFACE_WATER,
                                   (180, 213, 244))
     else:
         # Blue - Water (high confidence)
         dswx_ctable.SetColorEntry(WATER_UNCOLLAPSED_HIGH_CONF_CLEAR,
-                                  (0, 0, 255)) 
+                                  (0, 0, 255))
         # Light blue - Water (moderate conf.)
         dswx_ctable.SetColorEntry(WATER_UNCOLLAPSED_MODERATE_CONF_CLEAR,
-                                  (0, 127, 255))
+                                  (95, 127, 255))
         # Dark green - Partial surface water conservative
         dswx_ctable.SetColorEntry(
-            WATER_UNCOLLAPSED_PARTIAL_SURFACE_WATER_CONSERVATIVE_CLEAR, 
+            WATER_UNCOLLAPSED_PARTIAL_SURFACE_WATER_CONSERVATIVE_CLEAR,
                                   (0, 195, 0)) # 225 ok
         # Light green - Partial surface water aggressive
         dswx_ctable.SetColorEntry(
-            WATER_UNCOLLAPSED_PARTIAL_SURFACE_WATER_AGGRESSIVE_CLEAR, 
+            WATER_UNCOLLAPSED_PARTIAL_SURFACE_WATER_AGGRESSIVE_CLEAR,
                                   (150, 255, 150))
 
     # Dark blue - Ocean masked

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1174,8 +1174,8 @@ def _apply_aerosol_class_remapping_wtr1_class(wtr_1_layer,
                             (preliminary_cloud_layer != UINT8_FILL_VALUE)] += 8
 
 
-def _apply_aerosol_class_remapping(wtr_1_layer, fmask,
-        preliminary_cloud_layer,
+def _apply_aerosol_class_remapping(wtr_1_layer,
+        preliminary_cloud_layer, fmask,
         aerosol_not_water_to_moderate_conf_water_fmask_values,
         aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
         aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values,
@@ -1475,7 +1475,6 @@ def _get_cloud_layer_ctable():
     # - Mask snow/ice bit (1)
     # - Mask cloud bit (2)
     # - Class reassignment due to aerosol interpolation errors (3)
-    # rusty ocre / gray green / grayish yellow
 
     # White - Not masked
     mask_ctable.SetColorEntry(0, (255, 255, 255))
@@ -1495,7 +1494,7 @@ def _get_cloud_layer_ctable():
     mask_ctable.SetColorEntry(7, (127, 127, 255))
 
     # Light ocre - Aerosol reassignment ("0xE4CDA7")
-    mask_ctable.SetColorEntry(8, (288, 205, 167))
+    mask_ctable.SetColorEntry(8, (228, 205, 167))
     # Dark gray - Cloud shadow
     mask_ctable.SetColorEntry(9, (64, 64, 64))
     # Cyan - snow/ice

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -2035,8 +2035,11 @@ def _apply_cloud_masking(wtr_2_layer, cloud_layer):
     '''
 
     # If there's cloud shadow/adjacent to cloud/cloud shadow or
-    # cloud, then mark output as WTR_CLOUD_MASKED
-    wtr_layer[cloud_layer != 0] = WTR_CLOUD_MASKED
+    # cloud, and there was no remapping due to high aerosol
+    # bit 3 (value 2**3 = 8),
+    # then mark output as WTR_CLOUD_MASKED
+    wtr_layer[(cloud_layer != 0) &
+              (cloud_layer != 8)] = WTR_CLOUD_MASKED
 
     # If there's snow only (i.e., no cloud/cloud shadow),
     # the mark output as WTR_SNOW_MASKED

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -4576,6 +4576,9 @@ def generate_dswx_layers(input_list,
     preliminary_cloud_layer = _compute_preliminary_cloud_layer(
         fmask, mask_adjacent_to_cloud_mode)
 
+    # compute total number of pixels
+    total_number_of_pixels = length * width
+
     # create ocean mask
     if shoreline_shapefile is not None:
         ocean_mask = _create_ocean_mask(shoreline_shapefile,
@@ -4586,12 +4589,14 @@ def generate_dswx_layers(input_list,
 
         # update valid_array
         valid_array = np.logical_and(valid_array, ocean_mask)
+        n_not_ocean = np.sum(ocean_mask)
+    else:
+        n_not_ocean = total_number_of_pixels
 
     # create variables to compute spatial and cloud coverage
     n_valid = np.sum(valid_array)
     n_cloud_and_valid = np.sum(((preliminary_cloud_layer) != 0) & (valid_array))
     del valid_array
-    total_number_of_pixels = length * width
 
     # use floor integer to compute spatial and cloud coverage
     spatial_coverage = int(100 * float(n_valid) / total_number_of_pixels)
@@ -4599,11 +4604,6 @@ def generate_dswx_layers(input_list,
         cloud_coverage = 0
     else:
         cloud_coverage = int(100 * float(n_cloud_and_valid) / n_valid)
-
-    if ocean_mask is not None:
-        n_not_ocean = np.sum(ocean_mask) 
-    else:
-        n_not_ocean = total_number_of_pixels
 
     if n_not_ocean == 0:
         spatial_coverage_after_ocean_masking = 0

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1781,7 +1781,9 @@ def _add_snow_to_cloud_layer(wtr_2_layer, cloud_layer, fmask,
        wtr_2_layer: numpy.ndarray
             Cloud-unmasked interpreted water layer
        cloud_layer : numpy.ndarray
-            Preliminary cloud mask (without the snow/ice class)
+            Preliminary cloud mask (without the snow/ice class). This array
+            is updated within the function (mutable numpy.ndarray) and returned
+            after the snow/ice class is added to the layer.
        fmask: numpy ndarray
             HLS Fmask
        mask_adjacent_to_cloud_mode: str

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -3573,8 +3573,11 @@ def _populate_dswx_metadata_processing_parameters(
         mask_adjacent_to_cloud_mode
 
     # Copernicus class for forest masking
-    dswx_metadata_dict['FOREST_MASK_LANDCOVER_CLASSES'] = \
-        ','.join([str(c) for c in forest_mask_landcover_classes])
+    if forest_mask_landcover_classes:
+        dswx_metadata_dict['FOREST_MASK_LANDCOVER_CLASSES'] = \
+            ','.join([str(c) for c in forest_mask_landcover_classes])
+    else:
+        dswx_metadata_dict['FOREST_MASK_LANDCOVER_CLASSES'] = '-'
 
     # ocean masking distance from shoreline in km
     if shoreline_shapefile:

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1170,8 +1170,10 @@ def _apply_aerosol_class_remapping_wtr1_class(wtr_1_layer,
     wtr_1_layer[to_mask_array] = output_wtr1_class
 
     # set CLOUD layer bit (3): 2**3 = 8
-    preliminary_cloud_layer[(to_mask_array) &
-                            (preliminary_cloud_layer != UINT8_FILL_VALUE)] += 8
+    ind = np.where((to_mask_array) &
+                   (preliminary_cloud_layer != UINT8_FILL_VALUE))
+    preliminary_cloud_layer[ind] = np.bitwise_or(
+        preliminary_cloud_layer[ind], 2**3)
 
 
 def _apply_aerosol_class_remapping(wtr_1_layer,

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -3677,7 +3677,7 @@ def _populate_dswx_metadata_datasets(dswx_metadata_dict,
         dswx_metadata_dict['DEM_SOURCE'] = \
             os.path.basename(dem_file)
     else:
-        dswx_metadata_dict['DEM_SOURCE'] = '(not provided)'
+        dswx_metadata_dict['DEM_SOURCE'] = '-'
 
     if landcover_file_description:
         dswx_metadata_dict['LANDCOVER_SOURCE'] = landcover_file_description
@@ -3685,7 +3685,7 @@ def _populate_dswx_metadata_datasets(dswx_metadata_dict,
         dswx_metadata_dict['LANDCOVER_SOURCE'] = \
             os.path.basename(landcover_file)
     else:
-        dswx_metadata_dict['LANDCOVER_SOURCE'] = '(not provided)'
+        dswx_metadata_dict['LANDCOVER_SOURCE'] = '-'
 
     if worldcover_file_description:
         dswx_metadata_dict['WORLDCOVER_SOURCE'] = worldcover_file_description
@@ -3693,7 +3693,7 @@ def _populate_dswx_metadata_datasets(dswx_metadata_dict,
         dswx_metadata_dict['WORLDCOVER_SOURCE'] = \
             os.path.basename(worldcover_file)
     else:
-        dswx_metadata_dict['WORLDCOVER_SOURCE'] = '(not provided)'
+        dswx_metadata_dict['WORLDCOVER_SOURCE'] = '-'
 
     if shoreline_shapefile_description:
         dswx_metadata_dict['SHORELINE_SOURCE'] = \
@@ -3702,7 +3702,7 @@ def _populate_dswx_metadata_datasets(dswx_metadata_dict,
         dswx_metadata_dict['SHORELINE_SOURCE'] = \
             os.path.basename(shoreline_shapefile)
     else:
-        dswx_metadata_dict['SHORELINE_SOURCE'] = '(not provided)'
+        dswx_metadata_dict['SHORELINE_SOURCE'] = '-'
 
 
 def _populate_dswx_metadata_processing_parameters(
@@ -4470,6 +4470,9 @@ def generate_dswx_layers(input_list,
     logger.info(f'        ocean masking distance from shoreline in km:'
                 f' {ocean_masking_shoreline_distance_km}'
                 f'{ocean_masking_unused_parameters_str}')
+    if not apply_ocean_masking:
+        shoreline_shapefile = None
+        shoreline_shapefile_description = None
 
     logger.info(f'    apply aerosol water class remapping:'
                 f' {apply_aerosol_class_remapping}')

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -4347,7 +4347,7 @@ def generate_dswx_layers(input_list,
             check_ancillary_inputs_coverage = \
                 runconfig_constants.check_ancillary_inputs_coverage
         if apply_aerosol_class_remapping is None:
-            apply_aerosol_class_remapping = runconfig.constants.apply_aerosol_class_remapping
+            apply_aerosol_class_remapping = runconfig_constants.apply_aerosol_class_remapping
         if aerosol_not_water_to_moderate_conf_water_fmask_values is None:
             aerosol_not_water_to_moderate_conf_water_fmask_values = \
                 runconfig_constants.aerosol_not_water_to_moderate_conf_water_fmask_values

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1697,8 +1697,7 @@ def _compute_diagnostic_tests(blue, green, red, nir, swir1, swir2,
 def _compute_preliminary_cloud_layer(fmask, mask_adjacent_to_cloud_mode):
     """Compute a preliminary CLOUD layer without the snow/ice
        class. The CLOUD layer will be completed by a subsequent function
-       _add_snow_to_cloud_layer_and_apply_cloud_masking()
-       after the WTR-2 layer is generated.
+       _add_snow_to_cloud_layer().
 
        Parameters
        ----------
@@ -1710,13 +1709,21 @@ def _compute_preliminary_cloud_layer(fmask, mask_adjacent_to_cloud_mode):
             shadow (default); "ignore" - ignore the adjacent to cloud/
             cloud shadow classification; and 'cover' - covers these areas
             with a dilation algorithm (this option will be handled in
-            the subsequent function
-            _add_snow_to_cloud_layer_and_apply_cloud_masking())
+            the subsequent function _add_snow_to_cloud_layer())
 
        Returns
        -------
-       preliminary_cloud_layer : numpy.ndarray
             Preliminary cloud mask (without the snow/ice class)
+            with dtype of uint8 and values assigned as follows:
+                0: Not masked
+                1: Cloud shadow or adjacent to cloud/cloud shadow
+                4: Cloud
+                5: Cloud and class 1 (cloud shadow or adjacent to cloud/cloud shadow)
+                255: Fill value (no data)
+       See Also
+       ---------
+       _add_snow_to_cloud_layer : Add the snow bit encodings from `fmask` to
+       `preliminary_cloud_layer`
     """
     preliminary_cloud_layer = np.zeros(fmask.shape, dtype = np.uint8)
 
@@ -1730,7 +1737,7 @@ def _compute_preliminary_cloud_layer(fmask, mask_adjacent_to_cloud_mode):
          else: ignore this class)
     (*) 3 - Cloud shadow (output bit 0)
         4 - Snow/ice (output bit 1, will be assigned in the subsequent function:
-            _add_snow_to_cloud_layer_and_apply_cloud_masking())
+            _add_snow_to_cloud_layer())
         5 - Water
         6-7 - Aerosol quality:
               00 - Climatology aerosol
@@ -1766,7 +1773,6 @@ def _add_snow_to_cloud_layer(wtr_2_layer, cloud_layer, fmask,
     """Finish computing the CLOUD layer by adding the snow/ice class
        to the CLOUD layer.
        This function succeeds the function _compute_preliminary_cloud_layer()
-       and preceeds _apply_cloud_masking()
 
        Parameters
        ----------

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -4249,6 +4249,7 @@ def generate_dswx_layers(input_list,
     width = image_dict['width']
     invalid_ind = np.where(image_dict['invalid_ind_array'])
     valid_array = ~image_dict['invalid_ind_array']
+    del image_dict
 
     sun_azimuth_angle_meta = dswx_metadata_dict['MEAN_SUN_AZIMUTH_ANGLE'].split(', ')
     sun_zenith_angle_meta = dswx_metadata_dict['MEAN_SUN_ZENITH_ANGLE'].split(', ')

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -4257,6 +4257,12 @@ def generate_dswx_layers(input_list,
     logger.info(f'    mean azimuth angle: {sun_azimuth_angle}')
     logger.info(f'    mean elevation angle: {sun_elevation_angle}')
 
+    # check ancillary inputs
+    if check_ancillary_inputs_coverage:
+        _check_ancillary_inputs(dem_file, landcover_file, worldcover_file,
+                                shoreline_shapefile, geotransform,
+                                projection, length, width)
+
     # print input HLS product spatial and cloud coverage
     logger.info(f'data coverage:')
     if 'INPUT_HLS_PRODUCT_SPATIAL_COVERAGE' in dswx_metadata_dict.keys():
@@ -4304,11 +4310,6 @@ def generate_dswx_layers(input_list,
     dswx_metadata_dict['SPATIAL_COVERAGE'] = spatial_coverage
     dswx_metadata_dict['CLOUD_COVERAGE'] = cloud_coverage
 
-    # check ancillary inputs
-    if check_ancillary_inputs_coverage:
-        _check_ancillary_inputs(dem_file, landcover_file, worldcover_file,
-                                shoreline_shapefile, geotransform,
-                                projection, length, width)
 
     if dem_file is not None:
         # DEM

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1863,7 +1863,7 @@ def _apply_cloud_masking(wtr_2_layer, cloud_layer):
        wtr_layer : numpy.ndarray
               Cloud-masked interpreted water layer
     """
-    wtr_layer = np.zeros_like(wtr_2_layer)
+    wtr_layer = wtr_2_layer.copy()
 
     '''
     Cloud layer:

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -228,9 +228,7 @@ layer_names_to_args_dict = {
     'INFRARED_RGB': 'output_infrared_rgb_file'}
 
 
-METADATA_FIELDS_TO_COPY_FROM_HLS_LIST = ['SPATIAL_COVERAGE',
-                                         'CLOUD_COVERAGE',
-                                         'MEAN_SUN_AZIMUTH_ANGLE',
+METADATA_FIELDS_TO_COPY_FROM_HLS_LIST = ['MEAN_SUN_AZIMUTH_ANGLE',
                                          'MEAN_SUN_ZENITH_ANGLE',
                                          'MEAN_VIEW_AZIMUTH_ANGLE',
                                          'MEAN_VIEW_ZENITH_ANGLE',
@@ -1907,6 +1905,9 @@ def _load_hls_band_from_file(filename, image_dict, offset_dict, scale_dict,
         for k, v in metadata.items():
             if k.upper() in METADATA_FIELDS_TO_COPY_FROM_HLS_LIST:
                 dswx_metadata_dict[k.upper()] = v
+            elif k.upper() in ['SPATIAL_COVERAGE', 'CLOUD_COVERAGE']:
+                dswx_metadata_key = 'INPUT_HLS_PRODUCT_'+k.upper()
+                dswx_metadata_dict[dswx_metadata_key] = v
             elif (k.upper() == 'LANDSAT_PRODUCT_ID' or
                     k.upper() == 'PRODUCT_URI'):
                 dswx_metadata_dict['SENSOR_PRODUCT_ID'] = v
@@ -4198,6 +4199,13 @@ def generate_dswx_layers(input_list,
     sun_azimuth_angle_meta = dswx_metadata_dict['MEAN_SUN_AZIMUTH_ANGLE'].split(', ')
     sun_zenith_angle_meta = dswx_metadata_dict['MEAN_SUN_ZENITH_ANGLE'].split(', ')
 
+    if 'INPUT_HLS_PRODUCT_SPATIAL_COVERAGE' in dswx_metadata_dict.keys():
+        hls_product_spatial_coverage = dswx_metadata_dict[
+            'INPUT_HLS_PRODUCT_SPATIAL_COVERAGE']
+    if 'INPUT_HLS_PRODUCT_CLOUD_COVERAGE' in dswx_metadata_dict.keys():
+        hls_product_cloud_coverage = dswx_metadata_dict[
+            'INPUT_HLS_PRODUCT_CLOUD_COVERAGE']
+
     if len(sun_azimuth_angle_meta) == 2:
         sun_azimuth_angle = (float(sun_azimuth_angle_meta[0]) +
                             float(sun_azimuth_angle_meta[1])) / 2.0
@@ -4215,6 +4223,12 @@ def generate_dswx_layers(input_list,
     logger.info(f'Sun parameters (from HLS metadata):')
     logger.info(f'    mean azimuth angle: {sun_azimuth_angle}')
     logger.info(f'    mean elevation angle: {sun_elevation_angle}')
+
+    logger.info(f'Data coverage:')
+    logger.info(f'    Input HLS product spatial coverage [%]:'
+                f' {hls_product_spatial_coverage}')
+    logger.info(f'    Input HLS product cloud coverage [%]:'
+                f' {hls_product_cloud_coverage}')
 
     # check ancillary inputs
     if check_ancillary_inputs_coverage:

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1713,17 +1713,19 @@ def _compute_preliminary_cloud_layer(fmask, mask_adjacent_to_cloud_mode):
 
        Returns
        -------
-            Preliminary cloud mask (without the snow/ice class)
-            with dtype of uint8 and values assigned as follows:
+            preliminary_cloud_layer : numpy.ndarray
+                Preliminary cloud mask (without the snow/ice class)
+                with dtype of uint8 and values assigned as follows:
                 0: Not masked
                 1: Cloud shadow or adjacent to cloud/cloud shadow
                 4: Cloud
                 5: Cloud and class 1 (cloud shadow or adjacent to cloud/cloud shadow)
                 255: Fill value (no data)
+
        See Also
        ---------
-       _add_snow_to_cloud_layer : Add the snow bit encodings from `fmask` to
-       `preliminary_cloud_layer`
+            _add_snow_to_cloud_layer : Add the snow bit encodings from `fmask` to
+            `preliminary_cloud_layer`
     """
     preliminary_cloud_layer = np.zeros(fmask.shape, dtype = np.uint8)
 
@@ -1792,20 +1794,21 @@ def _add_snow_to_cloud_layer(wtr_2_layer, cloud_layer, fmask,
        Returns
        -------
        cloud_layer : numpy.ndarray
-            Cloud mask (without the snow/ice class)
-            with dtype of uint8 and values assigned as follows:
-        0: Not masked
-        1: Cloud shadow or adjacent to cloud/cloud shadow
-        2: Snow/ice
-        3: Snow/ice and class 1 (cloud shadow or adjacent to cloud/cloud
-        shadow)
-        4: Cloud
-        5: Cloud and class 1 (cloud shadow or adjacent to cloud/cloud
-        shadow)
-        6: Cloud and snow/ice
-        7: Cloud, snow/ice, and class 1 (cloud shadow or adjacent to
-        cloud/cloud shadow)
-        255: Fill value (no data)
+            Cloud mask (without the snow/ice class) with dtype of uint8 and
+            values assigned as follows:
+
+            0: Not masked
+            1: Cloud shadow or adjacent to cloud/cloud shadow
+            2: Snow/ice
+            3: Snow/ice and class 1 (cloud shadow or adjacent to cloud/cloud
+                shadow)
+            4: Cloud
+            5: Cloud and class 1 (cloud shadow or adjacent to cloud/cloud
+                shadow)
+            6: Cloud and snow/ice
+            7: Cloud, snow/ice, and class 1 (cloud shadow or adjacent to
+                cloud/cloud shadow)
+            255: Fill value (no data)
 
     """
 

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1496,9 +1496,7 @@ def _get_cloud_layer_ctable():
     mask_ctable.SetColorEntry(7, (127, 127, 255))
 
     # Light ocre - Aerosol reassignment ("0xE4CDA7")
-    # mask_ctable.SetColorEntry(8, (228, 205, 167))
-    # Grayish blue - Aerosol reassignment ("0x7393B3")
-    mask_ctable.SetColorEntry(8, (115, 147, 179))
+    mask_ctable.SetColorEntry(8, (228, 205, 167))
     # Dark gray - Cloud shadow
     mask_ctable.SetColorEntry(9, (64, 64, 64))
     # Cyan - snow/ice

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1792,8 +1792,21 @@ def _add_snow_to_cloud_layer(wtr_2_layer, cloud_layer, fmask,
        Returns
        -------
        cloud_layer : numpy.ndarray
-              Cloud mask
-    
+            Cloud mask (without the snow/ice class)
+            with dtype of uint8 and values assigned as follows:
+        0: Not masked
+        1: Cloud shadow or adjacent to cloud/cloud shadow
+        2: Snow/ice
+        3: Snow/ice and class 1 (cloud shadow or adjacent to cloud/cloud
+        shadow)
+        4: Cloud
+        5: Cloud and class 1 (cloud shadow or adjacent to cloud/cloud
+        shadow)
+        6: Cloud and snow/ice
+        7: Cloud, snow/ice, and class 1 (cloud shadow or adjacent to
+        cloud/cloud shadow)
+        255: Fill value (no data)
+
     """
 
     '''

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -3484,7 +3484,7 @@ def _populate_dswx_metadata_processing_parameters(
 
     # Copernicus class for forest masking
     dswx_metadata_dict['FOREST_MASK_LANDCOVER_CLASSES'] = \
-        ', '.join(forest_mask_landcover_classes)
+        ','.join([str(c) for c in forest_mask_landcover_classes])
 
     # ocean masking distance from shoreline in km
     dswx_metadata_dict['OCEAN_MASKING_SHORELINE_DISTANCE_KM'] = \
@@ -4174,7 +4174,7 @@ def generate_dswx_layers(input_list,
         dswx_metadata_dict,
         shadow_masking_algorithm=shadow_masking_algorithm,
         min_slope_angle=min_slope_angle,
-        max_sun_local_inc_angle=max_sun_local_inc_angle=,
+        max_sun_local_inc_angle=max_sun_local_inc_angle,
         mask_adjacent_to_cloud_mode=mask_adjacent_to_cloud_mode,
         forest_mask_landcover_classes=forest_mask_landcover_classes,
         ocean_masking_shoreline_distance_km =

--- a/src/proteus/schemas/dswx_hls.yaml
+++ b/src/proteus/schemas/dswx_hls.yaml
@@ -68,23 +68,23 @@ runconfig:
             check_ancillary_inputs_coverage: bool(required=False)
 
             # Apply aeresol masking
-            apply_aerosol_masking: bool(required=False)
+            apply_aerosol_class_remapping: bool(required=False)
 
-            # HLS Fmask values to convert not-water to high-confidence water
+            # HLS Fmask values to convert not-water to moderate-confidence water
             # in the presence of high aerosol
-            aerosol_not_water_to_high_conf_water_fmask_values: list(int(), min=0, required=False)
+            aerosol_not_water_to_moderate_conf_water_fmask_values: list(int(), min=0, required=False)
 
             # HLS Fmask values to convert moderate-confidence water to
             # high-confidence water in the presence of high aerosol
             aerosol_water_moderate_conf_to_high_conf_water_fmask_values: list(int(), min=0, required=False)
 
             # HLS Fmask values to convert partial surface water conservative to
-            # high-confidence water in the presence of high aerosol
-            aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values: list(int(), min=0, required=False)
+            # moderate-confidence water in the presence of high aerosol
+            aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values: list(int(), min=0, required=False)
 
             # HLS Fmask values to convert partial surface water aggressive to
-            # high-confidence water in the presence of high aerosol
-            aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values: list(int(), min=0, required=False)
+            # moderate-confidence water in the presence of high aerosol
+            aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values: list(int(), min=0, required=False)
 
             # Select shadow masking algorithm
             shadow_masking_algorithm: enum('otsu', 'sun_local_inc_angle', required=False)

--- a/src/proteus/schemas/dswx_hls.yaml
+++ b/src/proteus/schemas/dswx_hls.yaml
@@ -67,6 +67,9 @@ runconfig:
             # Check if ancillary inputs cover entirely the output product
             check_ancillary_inputs_coverage: bool(required=False)
 
+            # Apply aeresol masking
+            apply_aerosol_masking: bool(required=False)
+
             # HLS Fmask values to convert not-water to high-confidence water
             # in the presence of high aerosol
             aerosol_not_water_to_high_conf_water_fmask_values: list(int(), min=0, required=False)

--- a/src/proteus/schemas/dswx_hls.yaml
+++ b/src/proteus/schemas/dswx_hls.yaml
@@ -67,6 +67,22 @@ runconfig:
             # Check if ancillary inputs cover entirely the output product
             check_ancillary_inputs_coverage: bool(required=False)
 
+            # HLS Fmask values to convert not-water to high-confidence water
+            # in the presence of high aerosol
+            aerosol_not_water_to_high_conf_water_fmask_values: list(int(), min=0, required=False)
+
+            # HLS Fmask values to convert moderate-confidence water to
+            # high-confidence water in the presence of high aerosol
+            aerosol_water_moderate_conf_to_high_conf_water_fmask_values: list(int(), min=0, required=False)
+
+            # HLS Fmask values to convert partial surface water conservative to
+            # high-confidence water in the presence of high aerosol
+            aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values: list(int(), min=0, required=False)
+
+            # HLS Fmask values to convert partial surface water aggressive to
+            # high-confidence water in the presence of high aerosol
+            aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values: list(int(), min=0, required=False)
+
             # Select shadow masking algorithm
             shadow_masking_algorithm: enum('otsu', 'sun_local_inc_angle', required=False)
 

--- a/src/proteus/schemas/dswx_hls.yaml
+++ b/src/proteus/schemas/dswx_hls.yaml
@@ -67,6 +67,9 @@ runconfig:
             # Check if ancillary inputs cover entirely the output product
             check_ancillary_inputs_coverage: bool(required=False)
 
+            # Apply ocean masking
+            apply_ocean_masking: bool(required=False)
+
             # Apply aeresol masking
             apply_aerosol_class_remapping: bool(required=False)
 

--- a/src/proteus/schemas/dswx_hls.yaml
+++ b/src/proteus/schemas/dswx_hls.yaml
@@ -79,8 +79,10 @@ runconfig:
             # Define how areas adjacent to cloud/cloud-shadow should be handled
             mask_adjacent_to_cloud_mode: enum('mask', 'ignore', 'cover', required=False)
 
-            # Copernicus CGLS Land Cover 100m forest classes
-            copernicus_forest_classes: list(int(), min=0, required=False)
+            # Copernicus CGLS Land Cover 100m forest classes to mask out from
+            # the WTR-2 and WTR layer due to dark reflectance that is usually
+            # misinterpreted as water.
+            forest_mask_landcover_classes: list(int(), min=0, required=False)
 
             # Ocean masking distance from shoreline in km
             ocean_masking_shoreline_distance_km: num(required=False)

--- a/src/proteus/version.py
+++ b/src/proteus/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.5.3'
+VERSION = '1.0.0'

--- a/tests/test_dswx_hls_workflow.py
+++ b/tests/test_dswx_hls_workflow.py
@@ -94,7 +94,7 @@ def test_workflow():
         min_slope_angle = args.min_slope_angle,
         max_sun_local_inc_angle=args.max_sun_local_inc_angle,
         mask_adjacent_to_cloud_mode=args.mask_adjacent_to_cloud_mode,
-        copernicus_forest_classes=args.copernicus_forest_classes,
+        forest_mask_landcover_classes=args.forest_mask_landcover_classes,
         ocean_masking_shoreline_distance_km = \
             args.ocean_masking_shoreline_distance_km,
         flag_debug=args.flag_debug)

--- a/tests/test_dswx_hls_workflow.py
+++ b/tests/test_dswx_hls_workflow.py
@@ -90,6 +90,8 @@ def test_workflow():
         scratch_dir=args.scratch_dir,
         product_id=args.product_id,
         product_version=args.product_version,
+        check_ancillary_inputs_coverage=args.check_ancillary_inputs_coverage,
+        apply_aerosol_masking=args.apply_aerosol_masking,
         aerosol_not_water_to_high_conf_water_fmask_values =
             args.aerosol_not_water_to_high_conf_water_fmask_values,
         aerosol_water_moderate_conf_to_high_conf_water_fmask_values =

--- a/tests/test_dswx_hls_workflow.py
+++ b/tests/test_dswx_hls_workflow.py
@@ -91,15 +91,15 @@ def test_workflow():
         product_id=args.product_id,
         product_version=args.product_version,
         check_ancillary_inputs_coverage=args.check_ancillary_inputs_coverage,
-        apply_aerosol_masking=args.apply_aerosol_masking,
-        aerosol_not_water_to_high_conf_water_fmask_values =
-            args.aerosol_not_water_to_high_conf_water_fmask_values,
+        apply_aerosol_class_remapping=args.apply_aerosol_class_remapping,
+        aerosol_not_water_to_moderate_conf_water_fmask_values =
+            args.aerosol_not_water_to_moderate_conf_water_fmask_values,
         aerosol_water_moderate_conf_to_high_conf_water_fmask_values =
             args.aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
-        aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values =
-            args.aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
-        aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values =
-            args.aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values,
+        aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values =
+            args.aerosol_partial_surface_water_conservative_to_moderate_conf_water_fmask_values,
+        aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values =
+            args.aerosol_partial_surface_aggressive_to_moderate_conf_water_fmask_values,
         shadow_masking_algorithm=args.shadow_masking_algorithm,
         min_slope_angle = args.min_slope_angle,
         max_sun_local_inc_angle=args.max_sun_local_inc_angle,

--- a/tests/test_dswx_hls_workflow.py
+++ b/tests/test_dswx_hls_workflow.py
@@ -90,6 +90,14 @@ def test_workflow():
         scratch_dir=args.scratch_dir,
         product_id=args.product_id,
         product_version=args.product_version,
+        aerosol_not_water_to_high_conf_water_fmask_values =
+            args.aerosol_not_water_to_high_conf_water_fmask_values,
+        aerosol_water_moderate_conf_to_high_conf_water_fmask_values =
+            args.aerosol_water_moderate_conf_to_high_conf_water_fmask_values,
+        aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values =
+            args.aerosol_partial_surface_water_conservative_to_high_conf_water_fmask_values,
+        aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values =
+            args.aerosol_partial_surface_aggressive_to_high_conf_water_fmask_values,
         shadow_masking_algorithm=args.shadow_masking_algorithm,
         min_slope_angle = args.min_slope_angle,
         max_sun_local_inc_angle=args.max_sun_local_inc_angle,


### PR DESCRIPTION
This PR follows #38 and adds support to antimeridian ("dateline") crossing. The updates are limited to two functions: 1. The function that checks the input datasets `_check_ancillary_inputs()` and the function that relocate/reprojects the input datasets `_warp()`. In both functions, it's added a check for antimeridian crossing. If detected, OGR polygons are used in both sides of the antimeridian (immediately left or right) to crop the input bounding box (for `_check_ancillary_inputs()`) or input data (for `_warp()`). In the case of `_warp()`, the input data is cropped using GDAL Translate, which is followed by GDAL warp with two inputs, i.e., from left and right side of the antimeridian.