### PR TITLE
Update cloud color in BROWSE to be (175,175,175)

### DIFF
--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1410,7 +1410,7 @@ def _get_browse_ctable(
                               valid data, and will be fully transparent
     cloud_color : str
         How to color cloud in the color table. Defaults to 'gray'. Options are:
-            'cyan'          : cloud will be opaque cyan
+            'gray'          : cloud will be opaque gray
             'nodata'        : cloud pixels will be marked as not having
                               valid data, and will be fully transparent
     snow_color : str
@@ -1460,8 +1460,8 @@ def _get_browse_ctable(
         # Make sure to do this step after parsing the gray color for snow.
         out_ctable.SetColorEntry(WTR_CLOUD_MASKED, FILL_VALUE_RGBA)
     else:
-        # Cloud color will remain the same as in WTR
-        pass
+        # Make the gray cloud color for the browse a lighter gray than in WTR
+        out_ctable.SetColorEntry(WTR_CLOUD_MASKED, (175,175,175))
 
     if not_water_color == 'nodata':
         # The no-data fill RGBA was set by `_get_interpreted_dswx_ctable`.


### PR DESCRIPTION
This PR updates the cloud color in only the BROWSE image to be (175,175,175).

Before:
![OPERA_DSWx-HLS_L8_30_T10SEG_20220119T184616Z_20230307T000403Z_v1 0 0_BROWSE_BEFORE](https://user-images.githubusercontent.com/11642807/223591105-19aa18fb-4a8e-4a00-b8a9-1a44527a9bc4.png)


After:
![OPERA_DSWx-HLS_L8_30_T10SEG_20220119T184616Z_20230307T000403Z_v1 0 0_BROWSE](https://user-images.githubusercontent.com/11642807/223591125-cc1d0002-c7a1-4df5-8b98-ab2f25b823cd.png)
