### PR TITLE
Final changes to DSWx-HLS SAS for v1.0

### DIFF
--- a/src/proteus/defaults/dswx_hls.yaml
+++ b/src/proteus/defaults/dswx_hls.yaml
@@ -103,7 +103,7 @@ runconfig:
             # Copernicus CGLS Land Cover 100m forest classes to mask out from
             # the WTR-2 and WTR layer due to dark reflectance that is usually
             # misinterpreted as water.
-            forest_mask_landcover_classes: [20, 50, 80, 111, 113, 115, 116, 121, 123, 125, 126, 200]
+            forest_mask_landcover_classes: [20, 50, 111, 113, 115, 116, 121, 123, 125, 126]
 
             # Ocean masking distance from shoreline in km
             ocean_masking_shoreline_distance_km: 1

--- a/src/proteus/defaults/dswx_hls.yaml
+++ b/src/proteus/defaults/dswx_hls.yaml
@@ -67,7 +67,7 @@ runconfig:
             check_ancillary_inputs_coverage: True
 
             # Apply ocean masking
-            apply_ocean_masking: True
+            apply_ocean_masking: False
 
             # Apply aeresol class remapping
             apply_aerosol_class_remapping: True

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1569,7 +1569,7 @@ def _get_cloud_layer_ctable():
     # Light gray - Cloud
     mask_ctable.SetColorEntry(12, (192, 192, 192))
     # Gray - Cloud and cloud shadow
-    mask_ctable.SetColorEntry(13, (175, 175, 175))
+    mask_ctable.SetColorEntry(13, (127, 127, 127))
     # Magenta - Cloud and snow/ice
     mask_ctable.SetColorEntry(14, (255, 0, 255))
     # Light blue - Cloud, cloud shadow, and snow/ice

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -3733,9 +3733,9 @@ def _populate_dswx_metadata_processing_parameters(
        ----------
        dswx_metadata_dict : collections.OrderedDict
               Metadata dictionary
-       apply_ocean_masking: bool (optional)
+       apply_ocean_masking: bool
               Apply ocean masking
-       apply_aerosol_class_remapping: bool (optional)
+       apply_aerosol_class_remapping: bool
               Apply aerosol masking
        aerosol_not_water_to_high_conf_water_fmask_values: list(int)
               HLS Fmask values to convert not-water to high-confidence water

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -3959,7 +3959,7 @@ def _populate_dswx_metadata_processing_parameters(
     dswx_metadata_dict['OCEAN_MASKING_ENABLED'] = \
         'TRUE' if apply_ocean_masking else 'FALSE'
 
-    if apply_ocean_masking and shoreline_shapefile:
+    if apply_ocean_masking:
         dswx_metadata_dict['OCEAN_MASKING_SHORELINE_DISTANCE_KM'] = \
             ocean_masking_shoreline_distance_km
     else:

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -3814,7 +3814,7 @@ def _populate_dswx_metadata_processing_parameters(
     dswx_metadata_dict['OCEAN_MASKING_ENABLED'] = \
         'TRUE' if apply_ocean_masking else 'FALSE'
 
-    if shoreline_shapefile:
+    if apply_ocean_masking and shoreline_shapefile:
         dswx_metadata_dict['OCEAN_MASKING_SHORELINE_DISTANCE_KM'] = \
             ocean_masking_shoreline_distance_km
     else:

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -3941,7 +3941,7 @@ def _populate_dswx_metadata_processing_parameters(
             dswx_metadata_dict[aerosol_metadata_field_lower.upper()] = 'EMPTY'
 
     # shadow masking algorithm and parameters
-    dswx_metadata_dict['SHADOW_MASKING_ALGORITHM'] = shadow_masking_algorithm
+    dswx_metadata_dict['SHADOW_MASKING_ALGORITHM'] = shadow_masking_algorithm.upper()
     if shadow_masking_algorithm == 'sun_local_inc_angle':
         dswx_metadata_dict['MIN_SLOPE_ANGLE'] = min_slope_angle
         dswx_metadata_dict['MAX_SUN_LOCAL_INC_ANGLE'] = max_sun_local_inc_angle

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -1425,7 +1425,7 @@ def _get_interpreted_dswx_ctable(
     if layer_name == 'WTR':
 
         # Gray - CLOUD masked (Cloud/cloud-shadow)
-        dswx_ctable.SetColorEntry(WTR_CLOUD_MASKED, (127, 127, 127))
+        dswx_ctable.SetColorEntry(WTR_CLOUD_MASKED, (175, 175, 175))
 
         # Cyan - CLOUD masked (Snow)
         dswx_ctable.SetColorEntry(WTR_SNOW_MASKED, (0, 255, 255))
@@ -1510,7 +1510,7 @@ def _get_browse_ctable(
         out_ctable.SetColorEntry(WTR_CLOUD_MASKED, FILL_VALUE_RGBA)
     else:
         # Make the gray cloud color for the browse a lighter gray than in WTR
-        out_ctable.SetColorEntry(WTR_CLOUD_MASKED, (175,175,175))
+        out_ctable.SetColorEntry(WTR_CLOUD_MASKED, (175, 175, 175))
 
     if not_water_color == 'nodata':
         # The no-data fill RGBA was set by `_get_interpreted_dswx_ctable`.
@@ -1569,7 +1569,7 @@ def _get_cloud_layer_ctable():
     # Light gray - Cloud
     mask_ctable.SetColorEntry(12, (192, 192, 192))
     # Gray - Cloud and cloud shadow
-    mask_ctable.SetColorEntry(13, (127, 127, 127))
+    mask_ctable.SetColorEntry(13, (175, 175, 175))
     # Magenta - Cloud and snow/ice
     mask_ctable.SetColorEntry(14, (255, 0, 255))
     # Light blue - Cloud, cloud shadow, and snow/ice
@@ -2455,7 +2455,7 @@ def _get_binary_water_ctable():
     # Cyan - CLOUD masked (snow)
     binary_water_ctable.SetColorEntry(WTR_SNOW_MASKED, (0, 255, 255))
     # Gray - CLOUD masked (cloud/cloud-shadow)
-    binary_water_ctable.SetColorEntry(WTR_CLOUD_MASKED, (127, 127, 127))
+    binary_water_ctable.SetColorEntry(WTR_CLOUD_MASKED, (175, 175, 175))
     # Black (transparent) - Fill value
     binary_water_ctable.SetColorEntry(UINT8_FILL_VALUE, FILL_VALUE_RGBA)
     return binary_water_ctable

--- a/tests/test_dswx_hls_workflow.py
+++ b/tests/test_dswx_hls_workflow.py
@@ -24,7 +24,7 @@ def test_workflow():
         os.makedirs(test_data_directory, exist_ok=True)
 
     dataset_name = 's30_louisiana_mississippi'
-    dataset_url = ('https://zenodo.org/record/7683114/files/'
+    dataset_url = ('https://zenodo.org/record/7714162/files/'
                    's30_louisiana_mississippi.tar.gz?download=1')
 
     dataset_dir = os.path.join(test_data_directory, dataset_name)

--- a/tests/test_dswx_hls_workflow.py
+++ b/tests/test_dswx_hls_workflow.py
@@ -24,7 +24,7 @@ def test_workflow():
         os.makedirs(test_data_directory, exist_ok=True)
 
     dataset_name = 's30_louisiana_mississippi'
-    dataset_url = ('https://zenodo.org/record/7714162/files/'
+    dataset_url = ('https://zenodo.org/record/7714211/files/'
                    's30_louisiana_mississippi.tar.gz?download=1')
 
     dataset_dir = os.path.join(test_data_directory, dataset_name)


### PR DESCRIPTION
This PR provides final changes to the DSWx-HLS SAS for v1.0:
- Set default for `apply_ocean_masking` (in the default runconfig file) to `False`;
- Updates DSWx-HLS metadata:
    - Adds `AEROSOL_CLASS_REMAPPING_ENABLED` and `OCEAN_MASKING_ENABLED`;
    - Substitutes fields with value `-` by more meaningful values (addresses @nemo794 comment [here](https://github.com/nasa/PROTEUS/pull/38#discussion_r1127180356);
- Update URL pointing to the updated golden dataset in Zenodo (to be updated after all changes are approved).