### PR TITLE
Update Docker tag and Docker image tar file

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Then, from inside the cloned repository, build the Docker image:
 Load the Docker container image onto your computer:
 
 ```bash
-docker load -i docker/dockerimg_proteus_cal_val_3.3.tar
+docker load -i docker/dockerimg_proteus_final_4.tar
 ```
 
 See DSWx-HLS Science Algorithm Software (SAS) User Guide for instructions on processing via Docker.

--- a/build_docker_image.sh
+++ b/build_docker_image.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 IMAGE=opera/proteus
-t=cal_val_3.3
+t=final_4
 echo "IMAGE is $IMAGE:$t"
 
 # fail on any non-zero exit codes

--- a/load_docker_tar.sh
+++ b/load_docker_tar.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker load -i docker/dockerimg_proteus_cal_val_3.3.tar
+docker load -i docker/dockerimg_proteus_final_4.tar


### PR DESCRIPTION
This PR updates the proteus Docker tag to `final_4` and the Docker image tar file to `dockerimg_proteus_final_4.tar`