### PR TITLE
More antimeridian ("dateline") crossing fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Then, from inside the cloned repository, build the Docker image:
 Load the Docker container image onto your computer:
 
 ```bash
-docker load -i docker/dockerimg_proteus_final_4.tar
+docker load -i docker/dockerimg_proteus_final_4.1.tar
 ```
 
 See DSWx-HLS Science Algorithm Software (SAS) User Guide for instructions on processing via Docker.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Then, from inside the cloned repository, build the Docker image:
 Load the Docker container image onto your computer:
 
 ```bash
-docker load -i docker/dockerimg_proteus_cal_val_3.3.tar
+docker load -i docker/dockerimg_proteus_final_4.tar
 ```
 
 See DSWx-HLS Science Algorithm Software (SAS) User Guide for instructions on processing via Docker.

--- a/build_docker_image.sh
+++ b/build_docker_image.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 IMAGE=opera/proteus
-t=final_4
+t=final_4.1
 echo "IMAGE is $IMAGE:$t"
 
 # fail on any non-zero exit codes

--- a/build_docker_image.sh
+++ b/build_docker_image.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 IMAGE=opera/proteus
-t=cal_val_3.3
+t=final_4
 echo "IMAGE is $IMAGE:$t"
 
 # fail on any non-zero exit codes

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,12 +32,12 @@ RUN set -ex \
 
 # set default user and workdir
 WORKDIR /home/conda
-ADD dist/proteus-1.0.0.tar.gz .
+ADD dist/proteus-1.0.1.tar.gz .
 
 USER root
-RUN mkdir -p proteus-1.0.0/build
+RUN mkdir -p proteus-1.0.1/build
 RUN export PATH=/opt/conda/bin:$PATH
-WORKDIR /home/conda/proteus-1.0.0
+WORKDIR /home/conda/proteus-1.0.1
 RUN python3 setup.py install
 WORKDIR /home/conda
 
@@ -48,7 +48,7 @@ ENV GDAL_DIR /opt/conda
 ENV PATH $GDAL_DIR/bin:$PATH
 ENV GDAL_DATA $GDAL_DIR/share/gdal
 
-ENV PYTHONPATH /home/conda/proteus-1.0.0/src/:$PYTHONPATH
-ENV PATH /home/conda/proteus-1.0.0/bin/:$PATH
+ENV PYTHONPATH /home/conda/proteus-1.0.1/src/:$PYTHONPATH
+ENV PATH /home/conda/proteus-1.0.1/bin/:$PATH
 
 CMD [ "/bin/bash" ]

--- a/load_docker_tar.sh
+++ b/load_docker_tar.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker load -i docker/dockerimg_proteus_final_4.tar
+docker load -i docker/dockerimg_proteus_final_4.1.tar

--- a/load_docker_tar.sh
+++ b/load_docker_tar.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker load -i docker/dockerimg_proteus_cal_val_3.3.tar
+docker load -i docker/dockerimg_proteus_final_4.tar

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -30,6 +30,9 @@ If enabled, set all negative reflectance values to 1 before scaling is applied
 '''
 FLAG_CLIP_NEGATIVE_REFLECTANCE = True
 
+# Buffer for antimeridian crossing test (33 arcsec: ~ 1km)
+ANTIMERIDIAN_CROSSING_RIGHT_SIDE_TEST_BUFFER = 33 * 0.0002777 
+  
 LANDCOVER_LAT_MAX = 80
 LANDCOVER_LAT_MIN = -60
 WORLDCOVER_LAT_MAX = 84
@@ -4429,9 +4432,9 @@ def _check_ancillary_inputs(check_ancillary_inputs_coverage,
             logger.info(f'    left side (-180 -> +180): {check_1_str}')
 
             # Right side of the antimeridian crossing: +180 -> +360
-            buffer_in_degrees = 33 * 0.0002777  # buffer of 33 arcsec: ~ 1km
             file_polygon_2 = _get_ogr_polygon(
-                max_x + buffer_in_degrees, 90, max_x + 360, -90, file_srs)
+                max_x + ANTIMERIDIAN_CROSSING_RIGHT_SIDE_TEST_BUFFER,
+                90, max_x + 360, -90, file_srs)
             intersection_2 = tile_polygon.Intersection(file_polygon_2)
             file_polygon_2 = _get_ogr_polygon(min_x + 360, max_y,
                                               max_x + 360, min_y,

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -3155,17 +3155,21 @@ def _antimeridian_crossing_requires_special_handling(
 
     '''
 
-    # The dateline crossing by the tile is tested by the condition:
-    #     `tile_min_x < 180 and tile_max_x >= 180`
-    # The ancillary input only requires reprojection if it is in
-    # geographic coordinates and if its longitude domain is represented
-    # within the [-180, +180] range, verified by the test `min_x < -170`,
-    # rather than the [0, +360] interval. There's no specific reason why
-    # -170 is used. It could be -160, or even 0.
+    # Flag to indicate if the if the MGRS tile crosses the antimeridian.
+    flag_tile_crosses_antimeridian = tile_min_x < 180 and tile_max_x >= 180
 
+    # Flag to test if the ancillary input file is in geographic
+    # coordinates and if its longitude domain is represented
+    # within the [-180, +180] range, rather than the [0, +360] interval.
+    # This is verified by the test `min_x < -170`,
+    flag_input_geographic_and_longitude_not_0_360 = \
+        file_srs.IsGeographic() and file_min_x < -170
+
+    # If both are true, tile requires special handling due to the
+    # antimeridian crossing
     flag_requires_special_handling = (
-        file_srs.IsGeographic() and file_min_x < -170 and
-        tile_min_x < 180 and tile_max_x >= 180)
+        flag_tile_crosses_antimeridian and
+        flag_input_geographic_and_longitude_not_0_360)
 
     return flag_requires_special_handling
 

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -3168,7 +3168,8 @@ def _antimeridian_crossing_requires_special_handling(
     # Flag to test if the ancillary input file is in geographic
     # coordinates and if its longitude domain is represented
     # within the [-180, +180] range, rather than the [0, +360] interval.
-    # This is verified by the test `min_x < -170`,
+    # This is verified by the test `min_x < -170`. There's no specific reason
+    # why -170 is used. It could be -160, or even 0.
     flag_input_geographic_and_longitude_not_0_360 = \
         file_srs.IsGeographic() and file_min_x < -170
 

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -3153,6 +3153,10 @@ def _antimeridian_crossing_requires_special_handling(
     tile_max_x: float
         MGRS tile max longitude value in degrees
 
+    Returns
+    -------
+    flag_requires_special_handling : bool
+        Flag that indicate if the ancillary input requires special handling
     '''
 
     # Flag to indicate if the if the MGRS tile crosses the antimeridian.

--- a/src/proteus/dswx_hls.py
+++ b/src/proteus/dswx_hls.py
@@ -819,7 +819,7 @@ def _compare_dswx_hls_metadata(metadata_1, metadata_2):
                 break
             # Exclude metadata fields that are not required to be the same
             if k1 in ['PROCESSING_DATETIME', 'DEM_SOURCE', 'LANDCOVER_SOURCE',
-                      'WORLDCOVER_SOURCE']:
+                      'WORLDCOVER_SOURCE', 'SOFTWARE_VERSION']:
                 continue
             if metadata_2[k1] != v1:
                 flag_same_metadata = False

--- a/src/proteus/version.py
+++ b/src/proteus/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.0.0'
+VERSION = '1.0.1'


### PR DESCRIPTION
This PR addresses an issue reported by the PGE (thank you, @collinss-jpl) that is affecting some datasets that cross the dateline. The problem is that a buffer declared in the line [here](https://github.com/nasa/PROTEUS/blob/8b6aad1a67f2f4946aae7b5ff046de9df5b66a69/src/proteus/dswx_hls.py#L4385) that is used to check the ancillary input's coverage at the right side of the dateline is too small. In this PR, I'm increasing that buffer from 1 arcsec (0.00027777 deg ~= 30m) to 33 arcsec (about 1km).

I'm taking advantage that we are updating proteus and I'm also adding some other changes:
- Small indentation fixes, white spaces, etc;
- Add condition `min_x < -170` to detect when dateline crossing requires cropping/reprojected of the ancillary input. Dateline crossing only requires reprojection of the ancillary input if this input is in geographic coordinates and its longitude domain is represented using the longitude range [-180, +180] rather than [0, +360]. For example, if a DEM was provided using [0, +360] longitude values, a tile that crosses the dateline (~+180 deg long.) would be fully covered by the DEM without need of cropping or reprojecting it. To detect if the DEM uses the [-180, +180], we just assert that `min_x` is below `-170`.