### PR TITLE
Final Tweaks for conda switchover

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,6 +1,6 @@
-gdal=3.6.2
+gdal==3.6.2
 numpy
-python=3.10
+python==3.10.0
 ruamel.yaml
 scipy
 pytest

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,9 +1,10 @@
-gdal>=3.0
+gdal=3.6.2
 numpy
-python>=3.6
+python=3.10
 ruamel.yaml
 scipy
 pytest
 requests
 yamale
 setuptools
+mamba<=2.1.1


### PR DESCRIPTION
To get recent test builds to work, I've had to constrain some dependency versions.

The generated data rasters from the golden dataset inputs matched the expected outputs.

If the pinned python version is an issue, I can experiment bumping to higher versions.